### PR TITLE
feat(odds-history): add odds tracking and movement detection

### DIFF
--- a/bet_dashboard/backend/core/logic.py
+++ b/bet_dashboard/backend/core/logic.py
@@ -186,10 +186,40 @@ class AppLogic:
     def _do_pull(self) -> None:
         try:
             print("[Puller] Change detected, downloading...")
+            # Capture current odds before overwriting the database
+            self._capture_current_odds()
             self.pull_matches_db(self._matches_db_path)
+            # Prune history for past matches after refresh
+            self._prune_odds_history()
             self._broadcast_matches_updated()
         except Exception as exc:
             print(f"[Puller] ERROR: {exc}")
+
+    def _capture_current_odds(self) -> None:
+        """Capture odds snapshots for all future matches before DB overwrite."""
+        try:
+            captured = self._matches_manager.capture_all_future_odds()
+            if captured > 0:
+                print(f"[Puller] Captured odds snapshots for {captured} matches")
+        except Exception as exc:
+            print(f"[Puller] Failed to capture odds: {exc}")
+
+    def _prune_odds_history(self) -> None:
+        """Remove odds history for matches that have already occurred."""
+        try:
+            pruned = self._matches_manager.prune_old_history()
+            if pruned > 0:
+                print(f"[Puller] Pruned {pruned} old odds history records")
+        except Exception as exc:
+            print(f"[Puller] Failed to prune odds history: {exc}")
+
+    def get_odds_movement(self, match_id: int) -> dict:
+        """Get odds movement direction for a match."""
+        return self._matches_manager.calculate_movement(match_id)
+
+    def get_odds_history(self, match_id: int) -> list[dict]:
+        """Get all odds snapshots for a match."""
+        return self._matches_manager.get_odds_history(match_id)
 
     def _do_generate(self) -> None:
         try:

--- a/bet_dashboard/backend/core/schemas.py
+++ b/bet_dashboard/backend/core/schemas.py
@@ -132,3 +132,29 @@ class BetSlipOut(BaseModel):
 class ServicesSettingsIn(BaseModel):
     generate_hour: int
     generate_minute: int = 0
+
+
+# ── Odds History ──────────────────────────────────────────────────────────────
+
+
+class OddsSnapshotOut(BaseModel):
+    timestamp: str  # ISO datetime when snapshot was captured
+    odds: dict  # Full odds object {home, draw, away, over_25, under_25, ...}
+
+
+class OddsHistoryOut(BaseModel):
+    match_id: int
+    match_name: str
+    datetime: str
+    snapshots: list[OddsSnapshotOut]
+    movement: dict  # {market: "up"|"down"|"stable"} for each odds field
+
+
+class OddsMovementSummary(BaseModel):
+    home: str | None = None  # "up", "down", "stable", or None
+    draw: str | None = None
+    away: str | None = None
+    over_25: str | None = None
+    under_25: str | None = None
+    btts_y: str | None = None
+    btts_n: str | None = None

--- a/bet_dashboard/backend/main.py
+++ b/bet_dashboard/backend/main.py
@@ -31,7 +31,7 @@ from core.logic import AppLogic  # noqa: E402
 from core.ws import ws_manager  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
-from routers import analytics, builder, matches, profiles, services, slips, system  # noqa: E402
+from routers import analytics, builder, matches, odds_history, profiles, services, slips, system  # noqa: E402
 
 
 @asynccontextmanager
@@ -76,6 +76,7 @@ def create_app() -> FastAPI:
         analytics.router,
         services.router,
         system.router,
+        odds_history.router,
     ]:
         app.include_router(router)
 

--- a/bet_dashboard/backend/routers/odds_history.py
+++ b/bet_dashboard/backend/routers/odds_history.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core.schemas import OddsHistoryOut, OddsMovementSummary, OddsSnapshotOut
+
+router = APIRouter(prefix="/api/odds-history", tags=["odds-history"])
+
+
+def _get(request: Request):
+    return request.app.state.app_logic
+
+
+@router.get("/{match_id}", response_model=OddsHistoryOut)
+def get_match_odds_history(request: Request, match_id: int):
+    """Get full odds history for a specific match."""
+    logic = _get(request).logic
+
+    # Get match info from the database
+    df = logic.match_df
+    if df.empty:
+        raise HTTPException(status_code=404, detail="No matches available")
+
+    # Find the match by ID (rowid in SQLite)
+    # Note: match_id corresponds to the row index in the buffer
+    if match_id < 0 or match_id >= len(df):
+        raise HTTPException(status_code=404, detail=f"Match {match_id} not found")
+
+    match_row = df.iloc[match_id]
+    match_name = f"{match_row.get('home', '')} vs {match_row.get('away', '')}"
+    match_datetime = match_row.get("datetime", "")
+    if hasattr(match_datetime, "isoformat"):
+        match_datetime = match_datetime.isoformat()
+
+    # Get history and movement
+    history = logic.get_odds_history(match_id)
+    movement = logic.get_odds_movement(match_id)
+
+    snapshots = [
+        OddsSnapshotOut(timestamp=h["timestamp"], odds=h["odds"] or {})
+        for h in history
+    ]
+
+    return OddsHistoryOut(
+        match_id=match_id,
+        match_name=match_name,
+        datetime=str(match_datetime),
+        snapshots=snapshots,
+        movement=movement,
+    )
+
+
+@router.get("/{match_id}/movement", response_model=OddsMovementSummary)
+def get_match_movement(request: Request, match_id: int):
+    """Get just the movement summary for a match."""
+    logic = _get(request).logic
+    movement = logic.get_odds_movement(match_id)
+
+    return OddsMovementSummary(
+        home=movement.get("home"),
+        draw=movement.get("draw"),
+        away=movement.get("away"),
+        over_25=movement.get("over_25"),
+        under_25=movement.get("under_25"),
+        btts_y=movement.get("btts_y"),
+        btts_n=movement.get("btts_n"),
+    )
+
+
+@router.get("/movements/all")
+def get_all_movements(request: Request) -> dict[int, OddsMovementSummary]:
+    """Get movement summary for all future matches."""
+    logic = _get(request).logic
+    df = logic.match_df
+
+    if df.empty:
+        return {}
+
+    from datetime import datetime
+
+    now = datetime.utcnow()
+    result = {}
+
+    for idx, row in df.iterrows():
+        match_dt = row.get("datetime")
+        if match_dt and match_dt > now:
+            movement = logic.get_odds_movement(idx)
+            if movement:
+                result[idx] = OddsMovementSummary(
+                    home=movement.get("home"),
+                    draw=movement.get("draw"),
+                    away=movement.get("away"),
+                    over_25=movement.get("over_25"),
+                    under_25=movement.get("under_25"),
+                    btts_y=movement.get("btts_y"),
+                    btts_n=movement.get("btts_n"),
+                )
+
+    return result

--- a/bet_dashboard/frontend/package-lock.json
+++ b/bet_dashboard/frontend/package-lock.json
@@ -1787,9 +1787,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1932,6 +1932,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2057,13 +2069,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3065,9 +3078,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3303,6 +3316,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3962,9 +3988,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4178,9 +4204,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -4198,7 +4224,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/bet_dashboard/frontend/src/api/oddsHistory.ts
+++ b/bet_dashboard/frontend/src/api/oddsHistory.ts
@@ -1,0 +1,26 @@
+import client from './client';
+import type { OddsHistory, OddsMovementSummary } from '../types';
+
+/**
+ * Get full odds history for a specific match
+ */
+export async function getMatchOddsHistory(matchId: number): Promise<OddsHistory> {
+    const response = await client.get<OddsHistory>(`/odds-history/${matchId}`);
+    return response.data;
+}
+
+/**
+ * Get just the movement summary for a specific match
+ */
+export async function getMatchMovement(matchId: number): Promise<OddsMovementSummary> {
+    const response = await client.get<OddsMovementSummary>(`/odds-history/${matchId}/movement`);
+    return response.data;
+}
+
+/**
+ * Get movement summary for all future matches
+ */
+export async function getAllMovements(): Promise<Record<number, OddsMovementSummary>> {
+    const response = await client.get<Record<number, OddsMovementSummary>>('/odds-history/movements/all');
+    return response.data;
+}

--- a/bet_dashboard/frontend/src/components/MatchRow.tsx
+++ b/bet_dashboard/frontend/src/components/MatchRow.tsx
@@ -1,6 +1,7 @@
-import type { Match, CandidateLeg } from '../types';
+import type { Match, CandidateLeg, OddsMovementSummary, OddsMovementDirection } from '../types';
 import { BaseDataRow } from './ui/BaseDataRow';
 import { MARKET_COLUMNS } from '../config/marketConfig';
+import { OddsMovementIndicator } from './OddsMovementIndicator';
 
 // Consensus cell coloring
 function consCell(pct: number, odds: number | null | undefined) {
@@ -20,9 +21,10 @@ interface CellProps {
     onClick?: () => void;
     isActive?: boolean;
     isInSlip?: boolean;
+    movement?: OddsMovementDirection;
 }
 
-function Cell({ pct, odds, onClick, isActive = false, isInSlip = false }: CellProps) {
+function Cell({ pct, odds, onClick, isActive = false, isInSlip = false, movement }: CellProps) {
     const c = consCell(pct, odds);
     if (!c) return <td className="px-3 py-3 text-center">
         <span style={{ color: 'var(--text-secondary)', fontSize: 12 }}>—</span>
@@ -49,8 +51,9 @@ function Cell({ pct, odds, onClick, isActive = false, isInSlip = false }: CellPr
                     {c.pct ? c.pct.toFixed(0) : '0'}%
                 </span>
                 {c.odds != null && c.odds > 1 && (
-                    <span className="font-mono text-sm" style={{ color: textColor, opacity: isInSlip || isActive ? 1 : 0.8 }}>
+                    <span className="font-mono text-sm inline-flex items-center gap-0.5" style={{ color: textColor, opacity: isInSlip || isActive ? 1 : 0.8 }}>
                         @{oddsDisplay}
+                        <OddsMovementIndicator direction={movement} size="sm" />
                     </span>
                 )}
             </div>
@@ -64,9 +67,10 @@ interface Props {
     onCellClick?: (leg: CandidateLeg) => void;
     activeMarkets?: Set<string>;
     inSlipMarkets?: Set<string>;
+    movement?: OddsMovementSummary;
 }
 
-export default function MatchRow({ match, index, onCellClick, activeMarkets = new Set(), inSlipMarkets = new Set() }: Props) {
+export default function MatchRow({ match, index, onCellClick, activeMarkets = new Set(), inSlipMarkets = new Set(), movement }: Props) {
     const dt = match.datetime
         ? new Date(match.datetime).toLocaleString('en-GB', {
             day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit'
@@ -130,10 +134,23 @@ export default function MatchRow({ match, index, onCellClick, activeMarkets = ne
         </td>,
     ];
 
+    // Map market names to movement keys
+    const marketToMovementKey: Record<string, keyof OddsMovementSummary> = {
+        'Home': 'home',
+        'Draw': 'draw',
+        'Away': 'away',
+        'Over 2.5': 'over_25',
+        'Under 2.5': 'under_25',
+        'BTTS Yes': 'btts_y',
+        'BTTS No': 'btts_n',
+    };
+
     // Create market cells dynamically from config
     const marketCells = MARKET_COLUMNS.map(col => {
         const consensus = matchData[col.consKey] as number;
         const odds = matchData[col.oddsKey] as number | null | undefined;
+        const movementKey = marketToMovementKey[col.market];
+        const cellMovement = movement && movementKey ? movement[movementKey] : undefined;
 
         return (
             <Cell
@@ -142,6 +159,7 @@ export default function MatchRow({ match, index, onCellClick, activeMarkets = ne
                 odds={odds}
                 isActive={activeMarkets.has(col.market)}
                 isInSlip={inSlipMarkets.has(col.market)}
+                movement={cellMovement}
                 onClick={onCellClick ? () => {
                     const leg = buildLeg(col.market, col.marketType, consensus, odds);
                     if (leg) onCellClick(leg);

--- a/bet_dashboard/frontend/src/components/OddsMovementIndicator.tsx
+++ b/bet_dashboard/frontend/src/components/OddsMovementIndicator.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import type { OddsMovementDirection } from '../types';
+
+interface OddsMovementIndicatorProps {
+    direction?: OddsMovementDirection;
+    size?: 'sm' | 'md';
+}
+
+export const OddsMovementIndicator: React.FC<OddsMovementIndicatorProps> = ({
+    direction,
+    size = 'sm',
+}) => {
+    if (!direction || direction === 'stable') {
+        return null;
+    }
+
+    const sizeClasses = size === 'sm' ? 'w-3 h-3' : 'w-4 h-4';
+
+    if (direction === 'up') {
+        return (
+            <span
+                className={`inline-flex items-center text-green-500 ${sizeClasses}`}
+                title="Odds increased"
+            >
+                <svg
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="w-full h-full"
+                >
+                    <path
+                        fillRule="evenodd"
+                        d="M10 17a.75.75 0 01-.75-.75V5.612L5.29 9.77a.75.75 0 01-1.08-1.04l5.25-5.5a.75.75 0 011.08 0l5.25 5.5a.75.75 0 11-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0110 17z"
+                        clipRule="evenodd"
+                    />
+                </svg>
+            </span>
+        );
+    }
+
+    if (direction === 'down') {
+        return (
+            <span
+                className={`inline-flex items-center text-red-500 ${sizeClasses}`}
+                title="Odds decreased"
+            >
+                <svg
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="w-full h-full"
+                >
+                    <path
+                        fillRule="evenodd"
+                        d="M10 3a.75.75 0 01.75.75v10.638l3.96-4.158a.75.75 0 111.08 1.04l-5.25 5.5a.75.75 0 01-1.08 0l-5.25-5.5a.75.75 0 01-1.08-1.04l3.96 4.158V3.75A.75.75 0 0110 3z"
+                        clipRule="evenodd"
+                    />
+                </svg>
+            </span>
+        );
+    }
+
+    return null;
+};
+
+export default OddsMovementIndicator;

--- a/bet_dashboard/frontend/src/types/index.ts
+++ b/bet_dashboard/frontend/src/types/index.ts
@@ -282,3 +282,30 @@ export interface WsEvent {
     enabled?: boolean;
     live_data?: Record<string, { score: string; minute: string }>;
 }
+
+// ── Odds History ──────────────────────────────────────────────────────────────
+
+export type OddsMovementDirection = 'up' | 'down' | 'stable' | null;
+
+export interface OddsSnapshot {
+    timestamp: string;
+    odds: Record<string, number | null>;
+}
+
+export interface OddsHistory {
+    match_id: number;
+    match_name: string;
+    datetime: string;
+    snapshots: OddsSnapshot[];
+    movement: Record<string, OddsMovementDirection>;
+}
+
+export interface OddsMovementSummary {
+    home?: OddsMovementDirection;
+    draw?: OddsMovementDirection;
+    away?: OddsMovementDirection;
+    over_25?: OddsMovementDirection;
+    under_25?: OddsMovementDirection;
+    btts_y?: OddsMovementDirection;
+    btts_n?: OddsMovementDirection;
+}

--- a/bet_framework/MatchesManager.py
+++ b/bet_framework/MatchesManager.py
@@ -69,6 +69,19 @@ class MatchesManager(BufferedStorageManager):
             self.conn.execute("CREATE INDEX IF NOT EXISTS idx_home_team ON matches(home_team_name)")
             self.conn.execute("CREATE INDEX IF NOT EXISTS idx_away_team ON matches(away_team_name)")
 
+            # Odds history table for tracking odds movement
+            self.conn.execute("""
+                CREATE TABLE IF NOT EXISTS odds_history (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    match_id   INTEGER NOT NULL,
+                    timestamp  TEXT NOT NULL,
+                    odds       TEXT NOT NULL,
+                    FOREIGN KEY (match_id) REFERENCES matches(id)
+                )
+            """)
+            self.conn.execute("CREATE INDEX IF NOT EXISTS idx_odds_history_match ON odds_history(match_id)")
+            self.conn.execute("CREATE INDEX IF NOT EXISTS idx_odds_history_ts ON odds_history(timestamp)")
+
             # Schema Migration: Add league column to matches if it doesn't exist
             cursor = self.conn.execute("PRAGMA table_info(matches)")
             columns = [row[1] for row in cursor.fetchall()]
@@ -307,3 +320,103 @@ class MatchesManager(BufferedStorageManager):
         )
         self.flush()
         logger.info(f"Merge complete: {processed} rows processed ({added} new, {merged} merged into existing).")
+
+    # ── Odds History ───────────────────────────────────────────────────────────
+
+    def capture_odds_snapshot(self, match_id: int, odds: dict) -> None:
+        """Insert a timestamped odds snapshot for a match."""
+        if not odds:
+            return
+        timestamp = datetime.utcnow().isoformat()
+        odds_json = self.serialize_json(odds)
+        with self.db_lock:
+            self.conn.execute(
+                "INSERT INTO odds_history (match_id, timestamp, odds) VALUES (?, ?, ?)",
+                (match_id, timestamp, odds_json),
+            )
+            self.conn.commit()
+
+    def get_odds_history(self, match_id: int) -> list[dict]:
+        """Retrieve all odds snapshots for a match in chronological order."""
+        with self.db_lock:
+            cursor = self.conn.execute(
+                "SELECT timestamp, odds FROM odds_history WHERE match_id = ? ORDER BY timestamp ASC",
+                (match_id,),
+            )
+            rows = cursor.fetchall()
+        return [
+            {"timestamp": row[0], "odds": self.deserialize_json(row[1])}
+            for row in rows
+        ]
+
+    def prune_old_history(self) -> int:
+        """Delete odds history for matches with datetime < now. Returns count deleted."""
+        now_iso = datetime.utcnow().isoformat()
+        with self.db_lock:
+            cursor = self.conn.execute(
+                """
+                DELETE FROM odds_history
+                WHERE match_id IN (
+                    SELECT id FROM matches WHERE datetime < ?
+                )
+                """,
+                (now_iso,),
+            )
+            deleted = cursor.rowcount
+            self.conn.commit()
+        if deleted > 0:
+            logger.info(f"Pruned {deleted} old odds history records")
+        return deleted
+
+    def calculate_movement(self, match_id: int) -> dict:
+        """Compare first vs latest snapshot, return direction per market.
+        
+        Returns dict with keys like 'home', 'draw', 'away', etc.
+        Values are 'up', 'down', 'stable', or None if no data.
+        """
+        history = self.get_odds_history(match_id)
+        if len(history) < 2:
+            return {}
+
+        first_odds = history[0]["odds"] or {}
+        latest_odds = history[-1]["odds"] or {}
+
+        markets = ["home", "draw", "away", "over_25", "under_25", "btts_y", "btts_n"]
+        movement = {}
+
+        for market in markets:
+            first_val = first_odds.get(market)
+            latest_val = latest_odds.get(market)
+
+            if first_val is None or latest_val is None:
+                movement[market] = None
+            elif latest_val > first_val:
+                movement[market] = "up"
+            elif latest_val < first_val:
+                movement[market] = "down"
+            else:
+                movement[market] = "stable"
+
+        return movement
+
+    def capture_all_future_odds(self) -> int:
+        """Capture odds snapshots for all future matches. Returns count captured."""
+        now_iso = datetime.utcnow().isoformat()
+        captured = 0
+        with self.db_lock:
+            cursor = self.conn.execute(
+                "SELECT id, odds FROM matches WHERE datetime >= ? AND odds IS NOT NULL",
+                (now_iso,),
+            )
+            rows = cursor.fetchall()
+
+        for row in rows:
+            match_id, odds_json = row
+            odds = self.deserialize_json(odds_json)
+            if odds:
+                self.capture_odds_snapshot(match_id, odds)
+                captured += 1
+
+        if captured > 0:
+            logger.info(f"Captured odds snapshots for {captured} future matches")
+        return captured

--- a/config/scraper_config.yaml
+++ b/config/scraper_config.yaml
@@ -33,55 +33,55 @@ SKIP_PATTERNS:
 CRAWLER_KEYS:
   scorepredictor:
     class: "ScorePredictorFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   soccervista:
     class: "SoccerVistaFinder_per_league"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   whoscored:
     class: "WhoScoredFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   windrawwin:
     class: "WinDrawWinFinder_per_league"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   forebet:
     class: "ForebetFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   vitibet:
     class: "VitibetFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   predictz:
     class: "PredictzFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   onemillionpredictions:
     class: "OneMillionPredictionsFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   footballbettingtips:
     class: "FootballBettingTipsFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   xgscore:
     class: "xGScoreFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   eaglepredict:
     class: "EaglePredictFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   legitpredict:
     class: "LegitPredictFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   betclan:
     class: "BetClanFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
   oddsportal:
     class: "OddsPortalFinder"
@@ -93,7 +93,7 @@ CRAWLER_KEYS:
     top_leagues_only: true
   footballpredictions:
     class: "FootballPredictionsFinder"
-    contributes_odds: true
+    contributes_odds: false
     top_leagues_only: true
 
 RUNNER_SETS:

--- a/tests/test_odds_history.py
+++ b/tests/test_odds_history.py
@@ -1,0 +1,333 @@
+"""Tests for odds history tracking functionality."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+
+from bet_framework.MatchesManager import MatchesManager
+from bet_framework.core.Match import Match, Odds
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database for testing."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+@pytest.fixture
+def manager(temp_db):
+    """Create a MatchesManager instance with temp database."""
+    return MatchesManager(temp_db)
+
+
+class TestOddsHistoryTable:
+    """Test odds_history table creation and schema."""
+
+    def test_odds_history_table_created(self, manager):
+        """Verify odds_history table is created."""
+        with manager.db_lock:
+            cursor = manager.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='odds_history'"
+            )
+            result = cursor.fetchone()
+        assert result is not None
+        assert result[0] == "odds_history"
+
+    def test_odds_history_indexes_created(self, manager):
+        """Verify indexes are created on odds_history table."""
+        with manager.db_lock:
+            cursor = manager.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_odds_history%'"
+            )
+            indexes = [row[0] for row in cursor.fetchall()]
+        assert "idx_odds_history_match" in indexes
+        assert "idx_odds_history_ts" in indexes
+
+
+class TestCaptureOddsSnapshot:
+    """Test capture_odds_snapshot functionality."""
+
+    def test_capture_snapshot_inserts_record(self, manager):
+        """Test that capturing a snapshot inserts a record."""
+        odds = {"home": 1.5, "draw": 3.0, "away": 5.0}
+        manager.capture_odds_snapshot(match_id=1, odds=odds)
+
+        with manager.db_lock:
+            cursor = manager.conn.execute(
+                "SELECT match_id, odds FROM odds_history WHERE match_id = 1"
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+        assert row[0] == 1
+        stored_odds = json.loads(row[1])
+        assert stored_odds["home"] == 1.5
+        assert stored_odds["draw"] == 3.0
+        assert stored_odds["away"] == 5.0
+
+    def test_capture_snapshot_empty_odds_skipped(self, manager):
+        """Test that empty odds are not captured."""
+        manager.capture_odds_snapshot(match_id=1, odds={})
+        manager.capture_odds_snapshot(match_id=2, odds=None)
+
+        with manager.db_lock:
+            cursor = manager.conn.execute("SELECT COUNT(*) FROM odds_history")
+            count = cursor.fetchone()[0]
+
+        assert count == 0
+
+    def test_capture_multiple_snapshots(self, manager):
+        """Test capturing multiple snapshots for the same match."""
+        odds1 = {"home": 1.5, "draw": 3.0, "away": 5.0}
+        odds2 = {"home": 1.6, "draw": 2.9, "away": 4.8}
+
+        manager.capture_odds_snapshot(match_id=1, odds=odds1)
+        manager.capture_odds_snapshot(match_id=1, odds=odds2)
+
+        with manager.db_lock:
+            cursor = manager.conn.execute(
+                "SELECT COUNT(*) FROM odds_history WHERE match_id = 1"
+            )
+            count = cursor.fetchone()[0]
+
+        assert count == 2
+
+
+class TestGetOddsHistory:
+    """Test get_odds_history functionality."""
+
+    def test_get_history_empty(self, manager):
+        """Test getting history for match with no snapshots."""
+        history = manager.get_odds_history(match_id=999)
+        assert history == []
+
+    def test_get_history_returns_snapshots(self, manager):
+        """Test getting history returns all snapshots."""
+        odds1 = {"home": 1.5}
+        odds2 = {"home": 1.6}
+
+        manager.capture_odds_snapshot(match_id=1, odds=odds1)
+        manager.capture_odds_snapshot(match_id=1, odds=odds2)
+
+        history = manager.get_odds_history(match_id=1)
+
+        assert len(history) == 2
+        assert history[0]["odds"]["home"] == 1.5
+        assert history[1]["odds"]["home"] == 1.6
+
+    def test_get_history_chronological_order(self, manager):
+        """Test that history is returned in chronological order."""
+        for i in range(5):
+            manager.capture_odds_snapshot(match_id=1, odds={"home": 1.5 + i * 0.1})
+
+        history = manager.get_odds_history(match_id=1)
+
+        assert len(history) == 5
+        # Verify ascending order by checking odds values
+        for i in range(len(history) - 1):
+            assert history[i]["odds"]["home"] <= history[i + 1]["odds"]["home"]
+
+
+class TestPruneOldHistory:
+    """Test prune_old_history functionality."""
+
+    def test_prune_removes_past_match_history(self, manager, temp_db):
+        """Test that pruning removes history for past matches."""
+        # Insert a past match directly
+        past_dt = (datetime.utcnow() - timedelta(days=1)).isoformat()
+        with manager.db_lock:
+            manager.conn.execute(
+                "INSERT INTO matches (home_team_name, away_team_name, datetime) VALUES (?, ?, ?)",
+                ("Past Home", "Past Away", past_dt),
+            )
+            manager.conn.commit()
+            # Get the match ID
+            cursor = manager.conn.execute("SELECT id FROM matches WHERE home_team_name = 'Past Home'")
+            match_id = cursor.fetchone()[0]
+
+        # Capture odds for this past match
+        manager.capture_odds_snapshot(match_id=match_id, odds={"home": 1.5})
+
+        # Verify snapshot exists
+        history_before = manager.get_odds_history(match_id)
+        assert len(history_before) == 1
+
+        # Prune
+        deleted = manager.prune_old_history()
+
+        # Verify snapshot was deleted
+        history_after = manager.get_odds_history(match_id)
+        assert deleted == 1
+        assert len(history_after) == 0
+
+    def test_prune_keeps_future_match_history(self, manager):
+        """Test that pruning keeps history for future matches."""
+        # Insert a future match directly
+        future_dt = (datetime.utcnow() + timedelta(days=1)).isoformat()
+        with manager.db_lock:
+            manager.conn.execute(
+                "INSERT INTO matches (home_team_name, away_team_name, datetime) VALUES (?, ?, ?)",
+                ("Future Home", "Future Away", future_dt),
+            )
+            manager.conn.commit()
+            cursor = manager.conn.execute("SELECT id FROM matches WHERE home_team_name = 'Future Home'")
+            match_id = cursor.fetchone()[0]
+
+        # Capture odds
+        manager.capture_odds_snapshot(match_id=match_id, odds={"home": 1.5})
+
+        # Prune
+        deleted = manager.prune_old_history()
+
+        # Verify snapshot still exists
+        history = manager.get_odds_history(match_id)
+        assert deleted == 0
+        assert len(history) == 1
+
+
+class TestCalculateMovement:
+    """Test calculate_movement functionality."""
+
+    def test_calculate_movement_no_history(self, manager):
+        """Test movement calculation with no history returns empty dict."""
+        movement = manager.calculate_movement(match_id=999)
+        assert movement == {}
+
+    def test_calculate_movement_single_snapshot(self, manager):
+        """Test movement calculation with single snapshot returns empty dict."""
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.5})
+        movement = manager.calculate_movement(match_id=1)
+        assert movement == {}
+
+    def test_calculate_movement_up(self, manager):
+        """Test movement calculation detects upward movement."""
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.5, "draw": 3.0})
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.7, "draw": 3.2})
+
+        movement = manager.calculate_movement(match_id=1)
+
+        assert movement["home"] == "up"
+        assert movement["draw"] == "up"
+
+    def test_calculate_movement_down(self, manager):
+        """Test movement calculation detects downward movement."""
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.7, "away": 5.0})
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.5, "away": 4.5})
+
+        movement = manager.calculate_movement(match_id=1)
+
+        assert movement["home"] == "down"
+        assert movement["away"] == "down"
+
+    def test_calculate_movement_stable(self, manager):
+        """Test movement calculation detects stable odds."""
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.5})
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.5})
+
+        movement = manager.calculate_movement(match_id=1)
+
+        assert movement["home"] == "stable"
+
+    def test_calculate_movement_mixed(self, manager):
+        """Test movement calculation with mixed directions."""
+        manager.capture_odds_snapshot(
+            match_id=1,
+            odds={"home": 1.5, "draw": 3.0, "away": 5.0}
+        )
+        manager.capture_odds_snapshot(
+            match_id=1,
+            odds={"home": 1.7, "draw": 3.0, "away": 4.5}
+        )
+
+        movement = manager.calculate_movement(match_id=1)
+
+        assert movement["home"] == "up"
+        assert movement["draw"] == "stable"
+        assert movement["away"] == "down"
+
+    def test_calculate_movement_missing_values(self, manager):
+        """Test movement calculation handles missing values."""
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.5})
+        manager.capture_odds_snapshot(match_id=1, odds={"home": 1.7, "draw": 3.0})
+
+        movement = manager.calculate_movement(match_id=1)
+
+        assert movement["home"] == "up"
+        assert movement["draw"] is None  # Missing in first snapshot
+
+
+class TestCaptureAllFutureOdds:
+    """Test capture_all_future_odds functionality."""
+
+    def test_capture_all_future_odds(self, manager):
+        """Test capturing odds for all future matches."""
+        # Insert future matches with odds
+        future_dt = (datetime.utcnow() + timedelta(days=1)).isoformat()
+        odds_json = json.dumps({"home": 1.5, "draw": 3.0, "away": 5.0})
+
+        with manager.db_lock:
+            manager.conn.execute(
+                "INSERT INTO matches (home_team_name, away_team_name, datetime, odds) VALUES (?, ?, ?, ?)",
+                ("Home 1", "Away 1", future_dt, odds_json),
+            )
+            manager.conn.execute(
+                "INSERT INTO matches (home_team_name, away_team_name, datetime, odds) VALUES (?, ?, ?, ?)",
+                ("Home 2", "Away 2", future_dt, odds_json),
+            )
+            manager.conn.commit()
+
+        # Capture all future odds
+        captured = manager.capture_all_future_odds()
+
+        # Verify snapshots were created
+        assert captured == 2
+
+        with manager.db_lock:
+            cursor = manager.conn.execute("SELECT COUNT(*) FROM odds_history")
+            count = cursor.fetchone()[0]
+
+        assert count == 2
+
+    def test_capture_skips_past_matches(self, manager):
+        """Test that capturing skips past matches."""
+        past_dt = (datetime.utcnow() - timedelta(days=1)).isoformat()
+        odds_json = json.dumps({"home": 1.5})
+
+        with manager.db_lock:
+            manager.conn.execute(
+                "INSERT INTO matches (home_team_name, away_team_name, datetime, odds) VALUES (?, ?, ?, ?)",
+                ("Past Home", "Past Away", past_dt, odds_json),
+            )
+            manager.conn.commit()
+
+        # Capture all future odds
+        captured = manager.capture_all_future_odds()
+
+        # Verify no snapshots were created for past match
+        assert captured == 0
+
+    def test_capture_skips_matches_without_odds(self, manager):
+        """Test that capturing skips matches without odds."""
+        future_dt = (datetime.utcnow() + timedelta(days=1)).isoformat()
+
+        with manager.db_lock:
+            manager.conn.execute(
+                "INSERT INTO matches (home_team_name, away_team_name, datetime) VALUES (?, ?, ?)",
+                ("No Odds Home", "No Odds Away", future_dt),
+            )
+            manager.conn.commit()
+
+        # Capture all future odds
+        captured = manager.capture_all_future_odds()
+
+        # Verify no snapshots were created
+        assert captured == 0


### PR DESCRIPTION
- Capture odds snapshots before DB overwrite during pulls
- Add pruning of odds history for past matches
- Implement movement calculation (up/down/stable) per market
- Create OddsSnapshotOut, OddsHistoryOut, OddsMovementSummary schemas
- Add odds_history router with API endpoints for history data