### PR TITLE
feat: add demo data toggle for dashboard

### DIFF
--- a/bet_dashboard/backend/fixtures/demo_data.py
+++ b/bet_dashboard/backend/fixtures/demo_data.py
@@ -1,0 +1,1382 @@
+from __future__ import annotations
+
+import random
+import numpy as np
+from datetime import datetime, timedelta
+from typing import Any
+from dataclasses import dataclass, field
+from enum import Enum
+
+import pandas as pd
+
+from bet_framework.BetAssistant import BetAssistant
+from bet_framework.core.Slip import BetSlipConfig
+
+
+class Outcome(str, Enum):
+    PENDING = "Pending"
+    WON = "Won"
+    LOST = "Lost"
+    LIVE = "Live"
+
+
+class SlipStatus(str, Enum):
+    PENDING = "Pending"
+    WON = "Won"
+    LOST = "Lost"
+    LIVE = "Live"
+
+
+@dataclass
+class BetLeg:
+    match_name: str
+    datetime: str
+    market: str
+    market_type: str
+    odds: float
+    status: str
+    result_url: str | None
+    league: str | None
+
+
+@dataclass
+class BetSlip:
+    slip_id: int
+    date_generated: str
+    profile: str
+    total_odds: float
+    units: float
+    slip_status: str
+    legs: list[BetLeg]
+    net_profit: float | None = None
+
+
+@dataclass
+class Match:
+    match_id: str
+    datetime: str | None
+    home: str
+    away: str
+    sources: int
+    cons_home: int
+    cons_draw: int
+    cons_away: int
+    cons_over_25: int
+    cons_under_25: int
+    cons_btts_yes: int
+    cons_btts_no: int
+    cons_over_05: int
+    cons_under_05: int
+    cons_over_15: int
+    cons_under_15: int
+    cons_over_35: int
+    cons_under_35: int
+    cons_over_45: int
+    cons_under_45: int
+    cons_dc_1x: int
+    cons_dc_12: int
+    cons_dc_x2: int
+    odds_home: float
+    odds_draw: float
+    odds_away: float
+    odds_over_25: float
+    odds_under_25: float
+    odds_btts_yes: float
+    odds_btts_no: float
+    odds_over_05: float
+    odds_under_05: float
+    odds_over_15: float
+    odds_under_15: float
+    odds_over_35: float
+    odds_under_35: float
+    odds_over_45: float
+    odds_under_45: float
+    odds_dc_1x: float
+    odds_dc_12: float
+    odds_dc_x2: float
+    result_url: str | None
+    league: str | None
+
+
+class DemoDataProvider:
+    """
+    Deterministic demo data provider for dashboard demonstration.
+    Generates realistic betting data spanning 6 months with 3 profiles.
+    """
+
+    PROFILES = ["Conservative", "Aggressive", "Balanced"]
+    LEAGUES = [
+        "Premier League", "La Liga", "Bundesliga", "Serie A", "Ligue 1",
+        "Champions League", "Europa League", "Championship", "Serie B", "Primeira Liga"
+    ]
+    MARKETS = [
+        "Match Winner", "Over/Under 2.5", "Both Teams to Score",
+        "Over/Under 0.5", "Over/Under 1.5", "Over/Under 3.5", "Over/Under 4.5",
+        "Double Chance 1X", "Double Chance 12", "Double Chance X2"
+    ]
+    MARKET_TYPES = ["1X2", "Over/Under", "BTTS", "Over/Under", "Over/Under", "Over/Under", "Over/Under", "Double Chance", "Double Chance", "Double Chance"]
+
+    def __init__(self, seed: int = 42):
+        self.seed = seed
+        random.seed(seed)
+        np.random.seed(seed)
+        self._slips: list[BetSlip] = []
+        self._matches: list[Match] = []
+        self._odds_history: dict[int, list[dict]] = {}
+        self._match_id_counter = 0
+        self._slip_id_counter = 0
+        self._generate_all_data()
+
+    def _generate_all_data(self) -> None:
+        """Generate all demo data: matches, slips, odds history."""
+        # Generate matches first (needed for slips)
+        self._generate_matches()
+        # Generate slips referencing matches
+        self._generate_slips()
+        # Generate odds history for matches in slips
+        self._generate_odds_history()
+
+    def _generate_matches(self) -> None:
+        """Generate ~500 matches over 6 months."""
+        start_date = datetime(2026, 2, 1)  # 6 months back from August 2026
+        end_date = datetime(2026, 8, 1)
+        current_date = start_date
+        match_id = 0
+
+        teams_by_league = {
+            "Premier League": ["Arsenal", "Chelsea", "Liverpool", "Man City", "Man United", "Tottenham", "Newcastle", "Brighton", "Aston Villa", "West Ham"],
+            "La Liga": ["Real Madrid", "Barcelona", "Atletico Madrid", "Sevilla", "Valencia", "Villarreal", "Real Sociedad", "Athletic Bilbao", "Betis", "Girona"],
+            "Bundesliga": ["Bayern Munich", "Borussia Dortmund", "RB Leipzig", "Bayer Leverkusen", "Frankfurt", "Wolfsburg", "Freiburg", "Mainz", "Hoffenheim", "Stuttgart"],
+            "Serie A": ["Inter Milan", "AC Milan", "Juventus", "Napoli", "Roma", "Lazio", "Atalanta", "Fiorentina", "Bologna", "Torino"],
+            "Ligue 1": ["PSG", "Marseille", "Lyon", "Monaco", "Lille", "Rennes", "Nice", "Lens", "Reims", "Montpellier"],
+            "Champions League": ["Real Madrid", "Man City", "Bayern Munich", "PSG", "Inter Milan", "Arsenal", "Barcelona", "Dortmund"],
+            "Europa League": ["Liverpool", "Roma", "Bayer Leverkusen", "Brighton", "Marseille", "Atalanta", "Freiburg", "Rennes"],
+            "Championship": ["Leicester", "Leeds", "Southampton", "Ipswich", "Middlesbrough", "Norwich", "West Brom", "Hull City"],
+            "Serie B": ["Parma", "Como", "Venezia", "Cremonese", "Catanzaro", "Palermo", "Sampdoria", "Brescia"],
+            "Primeira Liga": ["Benfica", "Porto", "Sporting CP", "Braga", "Vitoria Guimaraes", "Familia", "Arouca", "Boavista"]
+        }
+
+        while current_date <= end_date:
+            # 2-5 matches per day
+            matches_today = random.randint(2, 5)
+            for _ in range(matches_today):
+                league = random.choice(self.LEAGUES)
+                teams = teams_by_league.get(league, ["Team A", "Team B"])
+                home, away = random.sample(teams, 2)
+
+                # Match datetime (evening)
+                match_dt = current_date.replace(hour=random.randint(18, 21), minute=random.choice([0, 15, 30, 45]))
+
+                # Consensus values (0-100)
+                cons_home = random.randint(30, 70)
+                cons_draw = random.randint(20, 40)
+                cons_away = 100 - cons_home - cons_draw + random.randint(-5, 5)
+                cons_away = max(10, min(50, cons_away))
+
+                # Other markets consensus
+                cons_over_25 = random.randint(35, 65)
+                cons_under_25 = 100 - cons_over_25 + random.randint(-3, 3)
+                cons_btts_yes = random.randint(40, 70)
+                cons_btts_no = 100 - cons_btts_yes + random.randint(-3, 3)
+
+                # Odds derived from consensus with bookmaker margin
+                margin = 1.05
+                odds_home = round(margin * 100 / max(1, cons_home), 2)
+                odds_draw = round(margin * 100 / max(1, cons_draw), 2)
+                odds_away = round(margin * 100 / max(1, cons_away), 2)
+                odds_over_25 = round(margin * 100 / max(1, cons_over_25), 2)
+                odds_under_25 = round(margin * 100 / max(1, cons_under_25), 2)
+                odds_btts_yes = round(margin * 100 / max(1, cons_btts_yes), 2)
+                odds_btts_no = round(margin * 100 / max(1, cons_btts_no), 2)
+
+                match = Match(
+                    match_id=str(match_id),
+                    datetime=match_dt.isoformat(),
+                    home=home,
+                    away=away,
+                    sources=random.randint(3, 15),
+                    cons_home=cons_home, cons_draw=cons_draw, cons_away=cons_away,
+                    cons_over_25=cons_over_25, cons_under_25=cons_under_25,
+                    cons_btts_yes=cons_btts_yes, cons_btts_no=cons_btts_no,
+                    cons_over_05=random.randint(80, 95), cons_under_05=random.randint(5, 20),
+                    cons_over_15=random.randint(60, 85), cons_under_15=random.randint(15, 40),
+                    cons_over_35=random.randint(20, 45), cons_under_35=random.randint(55, 80),
+                    cons_over_45=random.randint(10, 30), cons_under_45=random.randint(70, 90),
+                    cons_dc_1x=random.randint(55, 85), cons_dc_12=random.randint(70, 95), cons_dc_x2=random.randint(45, 75),
+                    odds_home=odds_home, odds_draw=odds_draw, odds_away=odds_away,
+                    odds_over_25=odds_over_25, odds_under_25=odds_under_25,
+                    odds_btts_yes=odds_btts_yes, odds_btts_no=odds_btts_no,
+                    odds_over_05=round(margin * 100 / random.randint(80, 95), 2),
+                    odds_under_05=round(margin * 100 / random.randint(5, 20), 2),
+                    odds_over_15=round(margin * 100 / random.randint(60, 85), 2),
+                    odds_under_15=round(margin * 100 / random.randint(15, 40), 2),
+                    odds_over_35=round(margin * 100 / random.randint(20, 45), 2),
+                    odds_under_35=round(margin * 100 / random.randint(55, 80), 2),
+                    odds_over_45=round(margin * 100 / random.randint(10, 30), 2),
+                    odds_under_45=round(margin * 100 / random.randint(70, 90), 2),
+                    odds_dc_1x=round(margin * 100 / random.randint(55, 85), 2),
+                    odds_dc_12=round(margin * 100 / random.randint(70, 95), 2),
+                    odds_dc_x2=round(margin * 100 / random.randint(45, 75), 2),
+                    result_url=f"https://example.com/match/{match_id}",
+                    league=league
+                )
+                self._matches.append(match)
+                match_id += 1
+            current_date += timedelta(days=1)
+
+        self._match_id_counter = match_id
+
+    def _generate_slips(self) -> None:
+        """Generate ~300-450 slips over 6 months across 3 profiles."""
+        start_date = datetime(2026, 2, 1)
+        end_date = datetime(2026, 8, 1)
+        slip_id = 1
+
+        # Profile configurations
+        profile_config = {
+            "Conservative": {
+                "odds_range": (1.5, 2.5),
+                "win_rate": 0.55,
+                "stake_range": (0.5, 1.5),
+                "legs_range": (1, 2),
+                "slips_per_month": (15, 20)
+            },
+            "Balanced": {
+                "odds_range": (2.0, 4.0),
+                "win_rate": 0.45,
+                "stake_range": (1.0, 2.5),
+                "legs_range": (1, 3),
+                "slips_per_month": (20, 25)
+            },
+            "Aggressive": {
+                "odds_range": (3.0, 8.0),
+                "win_rate": 0.35,
+                "stake_range": (1.5, 3.0),
+                "legs_range": (2, 4),
+                "slips_per_month": (15, 20)
+            }
+        }
+
+        current_date = start_date
+        while current_date <= end_date:
+            for profile in self.PROFILES:
+                config = profile_config[profile]
+                slips_this_month = random.randint(*config["slips_per_month"])
+                # Distribute slips across the month
+                for _ in range(slips_this_month):
+                    slip_date = current_date + timedelta(days=random.randint(0, 27))
+                    if slip_date > end_date:
+                        continue
+
+                    n_legs = random.randint(*config["legs_range"])
+                    stake = round(random.uniform(*config["stake_range"]), 1)
+
+                    # Select random matches from that time period
+                    available_matches = [m for m in self._matches
+                                         if m.datetime and abs((datetime.fromisoformat(m.datetime) - slip_date).days) <= 3]
+                    if not available_matches or len(available_matches) < n_legs:
+                        continue
+
+                    selected_matches = random.sample(available_matches, n_legs)
+                    legs = []
+                    total_odds = 1.0
+
+                    for match in selected_matches:
+                        market_idx = random.randint(0, len(self.MARKETS) - 1)
+                        market = self.MARKETS[market_idx]
+                        market_type = self.MARKET_TYPES[market_idx]
+
+                        # Pick odds based on market
+                        if market == "Match Winner":
+                            odds = random.choice([match.odds_home, match.odds_draw, match.odds_away])
+                        elif market == "Over/Under 2.5":
+                            odds = random.choice([match.odds_over_25, match.odds_under_25])
+                        elif market == "Both Teams to Score":
+                            odds = random.choice([match.odds_btts_yes, match.odds_btts_no])
+                        else:
+                            odds = random.uniform(*config["odds_range"])
+
+                        odds = round(odds, 2)
+                        total_odds *= odds
+
+                        # Determine status based on profile win rate and date
+                        if slip_date > datetime(2026, 7, 15):  # Recent matches - more pending/live
+                            status_roll = random.random()
+                            if status_roll < 0.15:
+                                status = Outcome.PENDING.value
+                            elif status_roll < 0.20:
+                                status = Outcome.LIVE.value
+                            else:
+                                status = random.choices([Outcome.WON.value, Outcome.LOST.value],
+                                                          weights=[config["win_rate"], 1 - config["win_rate"]])[0]
+                        else:
+                            # Older matches - mostly settled
+                            status_roll = random.random()
+                            if status_roll < 0.05:
+                                status = Outcome.PENDING.value
+                            else:
+                                status = random.choices([Outcome.WON.value, Outcome.LOST.value],
+                                                          weights=[config["win_rate"], 1 - config["win_rate"]])[0]
+
+                        leg = BetLeg(
+                            match_name=f"{match.home} vs {match.away}",
+                            datetime=match.datetime or slip_date.isoformat(),
+                            market=market,
+                            market_type=market_type,
+                            odds=odds,
+                            status=status,
+                            result_url=match.result_url,
+                            league=match.league
+                        )
+                        legs.append(leg)
+
+                    total_odds = round(total_odds, 2)
+
+                    # Determine slip status
+                    leg_statuses = [leg.status for leg in legs]
+                    if any(s == Outcome.LIVE.value for s in leg_statuses):
+                        slip_status = SlipStatus.LIVE.value
+                    elif any(s == Outcome.PENDING.value for s in leg_statuses):
+                        slip_status = SlipStatus.PENDING.value
+                    elif all(s == Outcome.WON.value for s in leg_statuses):
+                        slip_status = SlipStatus.WON.value
+                    elif all(s == Outcome.LOST.value for s in leg_statuses):
+                        slip_status = SlipStatus.LOST.value
+                    else:
+                        slip_status = SlipStatus.LOST.value  # Mixed = lost for accumulator
+
+                    # Calculate net profit for settled slips
+                    net_profit = None
+                    if slip_status in (SlipStatus.WON.value, SlipStatus.LOST.value):
+                        if slip_status == SlipStatus.WON.value:
+                            net_profit = round((total_odds - 1) * stake, 2)
+                        else:
+                            net_profit = round(-stake, 2)
+
+                    slip = BetSlip(
+                        slip_id=slip_id,
+                        date_generated=slip_date.strftime("%Y-%m-%d"),
+                        profile=profile,
+                        total_odds=total_odds,
+                        units=stake,
+                        slip_status=slip_status,
+                        legs=legs,
+                        net_profit=net_profit
+                    )
+                    self._slips.append(slip)
+                    slip_id += 1
+            current_date += timedelta(days=30)
+
+        self._slip_id_counter = slip_id
+
+    def _generate_odds_history(self) -> None:
+        """Generate odds history for matches referenced in slips."""
+        # Get unique match IDs from slips
+        match_ids_in_slips = set()
+        for slip in self._slips:
+            for leg in slip.legs:
+                if leg.result_url:
+                    # Extract match_id from URL
+                    try:
+                        match_id = int(leg.result_url.split("/")[-1])
+                        match_ids_in_slips.add(match_id)
+                    except (ValueError, IndexError):
+                        pass
+
+        # Generate 30 days of history for each match
+        for match_id in match_ids_in_slips:
+            if match_id >= len(self._matches):
+                continue
+            match = self._matches[match_id]
+            if not match.datetime:
+                continue
+
+            match_dt = datetime.fromisoformat(match.datetime)
+            history = []
+            for days_before in range(30, 0, -1):
+                snapshot_dt = match_dt - timedelta(days=days_before)
+                # Odds drift slightly over time
+                drift = random.uniform(-0.15, 0.15)
+                odds = {
+                    "home": round(max(1.01, match.odds_home + drift), 2),
+                    "draw": round(max(1.01, match.odds_draw + drift), 2),
+                    "away": round(max(1.01, match.odds_away + drift), 2),
+                    "over_25": round(max(1.01, match.odds_over_25 + drift), 2),
+                    "under_25": round(max(1.01, match.odds_under_25 + drift), 2),
+                    "btts_yes": round(max(1.01, match.odds_btts_yes + drift), 2),
+                    "btts_no": round(max(1.01, match.odds_btts_no + drift), 2),
+                }
+                history.append({
+                    "timestamp": snapshot_dt.isoformat(),
+                    "odds": odds
+                })
+            self._odds_history[match_id] = history
+
+    # ── Public API methods matching router expectations ─────────────────────────
+
+    def get_analytics(self, profiles: list[str] | None, date_from: str | None, date_to: str | None) -> dict[str, Any]:
+        """Return analytics data matching AnalyticsData schema."""
+        filtered_slips = self._filter_slips(profiles, date_from, date_to)
+        settled_slips = [s for s in filtered_slips if s.slip_status in (SlipStatus.WON.value, SlipStatus.LOST.value)]
+
+        # History (daily P&L)
+        history = self._calculate_daily_summary(settled_slips, date_from, date_to)
+
+        # Market accuracy
+        market_accuracy = self._calculate_market_accuracy(settled_slips)
+
+        # PnL by market
+        pnl_by_market = self._pnl_by_market(settled_slips)
+
+        # Correlation
+        correlation = self._calculate_correlation_data(settled_slips)
+
+        # Profile scatter
+        profile_scatter = self._profile_scatter(settled_slips)
+
+        # Stats
+        stats = self._calculate_stats(settled_slips, filtered_slips)
+
+        # Profiles list
+        all_profiles = sorted({s.profile for s in self._slips})
+
+        # Market breakdown
+        market_breakdown = self._market_breakdown(settled_slips)
+
+        # League breakdown
+        league_breakdown = self._league_breakdown(settled_slips)
+
+        # Rolling edge
+        rolling_edge = self._calculate_rolling_edge(settled_slips, 14)
+
+        # Drawdown
+        drawdown = self._calculate_drawdown(history)
+
+        # Return distribution
+        return_distribution = self._calculate_return_distribution(settled_slips)
+
+        # Time patterns
+        time_patterns = self._calculate_time_patterns(settled_slips)
+
+        # Correlation matrix
+        correlation_matrix = self._correlation_matrix(settled_slips)
+
+        return {
+            "history": history,
+            "market_accuracy": market_accuracy,
+            "pnl_by_market": pnl_by_market,
+            "odds_distribution": self._odds_distribution(settled_slips),
+            "correlation": correlation,
+            "profile_scatter": profile_scatter,
+            "stats": stats,
+            "profiles": all_profiles,
+            "market_breakdown": market_breakdown,
+            "league_breakdown": league_breakdown,
+            "rolling_edge": rolling_edge,
+            "drawdown": drawdown,
+            "return_distribution": return_distribution,
+            "time_patterns": time_patterns,
+            "correlation_matrix": correlation_matrix,
+        }
+
+    def get_slips(self, profiles: list[str] | None, date_from: str | None, date_to: str | None,
+                  hide_settled: bool, live_only: bool) -> dict[str, Any]:
+        """Return slips data matching SlipsPage schema."""
+        filtered = self._filter_slips(profiles, date_from, date_to)
+
+        if hide_settled:
+            filtered = [s for s in filtered if s.slip_status not in (SlipStatus.WON.value, SlipStatus.LOST.value)]
+        if live_only:
+            filtered = [s for s in filtered if any(leg.status == Outcome.LIVE.value for leg in s.legs)]
+
+        slips_data = []
+        for slip in filtered:
+            legs_data = []
+            for leg in slip.legs:
+                legs_data.append({
+                    "match_name": leg.match_name,
+                    "datetime": leg.datetime,
+                    "market": leg.market,
+                    "market_type": leg.market_type,
+                    "odds": leg.odds,
+                    "status": leg.status,
+                    "result_url": leg.result_url,
+                    "league": leg.league
+                })
+            slips_data.append({
+                "slip_id": slip.slip_id,
+                "date_generated": slip.date_generated,
+                "profile": slip.profile,
+                "total_odds": slip.total_odds,
+                "units": slip.units,
+                "slip_status": slip.slip_status,
+                "legs": legs_data,
+                "net_profit": slip.net_profit
+            })
+
+        # Stats
+        settled = [s for s in filtered if s.slip_status in (SlipStatus.WON.value, SlipStatus.LOST.value)]
+        stats = self._calculate_stats(settled, filtered)
+
+        # Profiles with slips
+        all_slips_for_profiles = self._filter_slips(None, date_from, date_to)
+        profiles_with_slips = sorted({s.profile for s in all_slips_for_profiles})
+
+        return {
+            "slips": slips_data,
+            "stats": stats,
+            "profiles": profiles_with_slips
+        }
+
+    def get_matches(self, page: int = 1, page_size: int = 40, search: str | None = None,
+                    date_from: str | None = None, date_to: str | None = None,
+                    sort_by: str = "datetime", sort_dir: str = "asc",
+                    min_consensus: int | None = None, min_odds: float | None = None,
+                    only_significant_movement: bool = False) -> dict[str, Any]:
+        """Return matches data matching MatchesPage schema."""
+        filtered = self._matches
+
+        if search:
+            search_lower = search.lower()
+            filtered = [m for m in filtered if search_lower in m.home.lower() or search_lower in m.away.lower()]
+
+        if date_from:
+            filtered = [m for m in filtered if m.datetime and m.datetime >= date_from]
+        if date_to:
+            filtered = [m for m in filtered if m.datetime and m.datetime <= date_to]
+
+        # Apply min_consensus filter
+        if min_consensus is not None and min_consensus > 0:
+            consensus_fields = [
+                "cons_home", "cons_draw", "cons_away",
+                "cons_over_25", "cons_under_25",
+                "cons_btts_yes", "cons_btts_no",
+                "cons_over_05", "cons_under_05",
+                "cons_over_15", "cons_under_15",
+                "cons_over_35", "cons_under_35",
+                "cons_over_45", "cons_under_45",
+                "cons_dc_1x", "cons_dc_12", "cons_dc_x2"
+            ]
+            filtered = [m for m in filtered if any(getattr(m, field, 0) >= min_consensus for field in consensus_fields)]
+
+        # Apply min_odds filter
+        if min_odds is not None and min_odds > 1.0:
+            odds_fields = [
+                "odds_home", "odds_draw", "odds_away",
+                "odds_over_25", "odds_under_25",
+                "odds_btts_yes", "odds_btts_no",
+                "odds_over_05", "odds_under_05",
+                "odds_over_15", "odds_under_15",
+                "odds_over_35", "odds_under_35",
+                "odds_over_45", "odds_under_45",
+                "odds_dc_1x", "odds_dc_12", "odds_dc_x2"
+            ]
+            filtered = [m for m in filtered if any(getattr(m, field, 0) >= min_odds for field in odds_fields)]
+
+        # Apply only_significant_movement filter
+        if only_significant_movement:
+            filtered = [m for m in filtered if m.match_id in self._odds_history and len(self._odds_history[m.match_id]) >= 2]
+            # Check if any market has significant movement
+            def has_significant_movement(match):
+                if match.match_id not in self._odds_history:
+                    return False
+                history = self._odds_history[match.match_id]
+                if len(history) < 2:
+                    return False
+                first = history[0]["odds"]
+                last = history[-1]["odds"]
+                for key in first:
+                    if key in last:
+                        change = (last[key] - first[key]) / first[key] * 100
+                        if abs(change) > 2:
+                            return True
+                return False
+            filtered = [m for m in filtered if has_significant_movement(m)]
+
+        # Sort
+        reverse = sort_dir == "desc"
+        if sort_by == "datetime":
+            filtered.sort(key=lambda m: m.datetime or "", reverse=reverse)
+        elif sort_by == "home":
+            filtered.sort(key=lambda m: m.home, reverse=reverse)
+        elif sort_by == "away":
+            filtered.sort(key=lambda m: m.away, reverse=reverse)
+        elif sort_by == "sources":
+            filtered.sort(key=lambda m: m.sources, reverse=reverse)
+
+        total = len(filtered)
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        start = (page - 1) * page_size
+        end = start + page_size
+        page_matches = filtered[start:end]
+
+        matches_data = []
+        for m in page_matches:
+            matches_data.append({
+                "match_id": m.match_id,
+                "datetime": m.datetime,
+                "home": m.home,
+                "away": m.away,
+                "sources": m.sources,
+                "cons_home": m.cons_home, "cons_draw": m.cons_draw, "cons_away": m.cons_away,
+                "cons_over_25": m.cons_over_25, "cons_under_25": m.cons_under_25,
+                "cons_btts_yes": m.cons_btts_yes, "cons_btts_no": m.cons_btts_no,
+                "cons_over_05": m.cons_over_05, "cons_under_05": m.cons_under_05,
+                "cons_over_15": m.cons_over_15, "cons_under_15": m.cons_under_15,
+                "cons_over_35": m.cons_over_35, "cons_under_35": m.cons_under_35,
+                "cons_over_45": m.cons_over_45, "cons_under_45": m.cons_under_45,
+                "cons_dc_1x": m.cons_dc_1x, "cons_dc_12": m.cons_dc_12, "cons_dc_x2": m.cons_dc_x2,
+                "odds_home": m.odds_home, "odds_draw": m.odds_draw, "odds_away": m.odds_away,
+                "odds_over_25": m.odds_over_25, "odds_under_25": m.odds_under_25,
+                "odds_btts_yes": m.odds_btts_yes, "odds_btts_no": m.odds_btts_no,
+                "odds_over_05": m.odds_over_05, "odds_under_05": m.odds_under_05,
+                "odds_over_15": m.odds_over_15, "odds_under_15": m.odds_under_15,
+                "odds_over_35": m.odds_over_35, "odds_under_35": m.odds_under_35,
+                "odds_over_45": m.odds_over_45, "odds_under_45": m.odds_under_45,
+                "odds_dc_1x": m.odds_dc_1x, "odds_dc_12": m.odds_dc_12, "odds_dc_x2": m.odds_dc_x2,
+                "result_url": m.result_url,
+                "league": m.league
+            })
+
+        return {
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "matches": matches_data
+        }
+
+    def get_profiles(self) -> dict[str, Any]:
+        """Return demo profiles."""
+        profiles = {
+            "Conservative": {
+                "target_odds": 2.0, "target_legs": 1, "max_legs_overflow": 1,
+                "consensus_floor": 60, "min_odds": 1.5,
+                "included_markets": ["Match Winner", "Double Chance 1X"],
+                "included_leagues": ["Premier League", "La Liga", "Bundesliga"],
+                "tolerance_factor": 1.2, "stop_threshold": 0.02,
+                "min_legs_fill_ratio": 0.8, "quality_vs_balance": 0.7, "consensus_vs_sources": 0.6,
+                "units": 1.0, "target_payout": 10.0, "run_daily_count": 1,
+                "consensus_shrinkage_k": 10, "min_source_edge": 2.0,
+                "max_single_leg_odds": 3.0, "tol_lower": 0.8, "tol_upper": 1.2,
+                "balance_decay": "linear", "min_pick_quality": 0.6,
+                "odds_movement_weight": 0.3, "odds_movement_strength_min": 0.05
+            },
+            "Balanced": {
+                "target_odds": 3.5, "target_legs": 2, "max_legs_overflow": 1,
+                "consensus_floor": 50, "min_odds": 1.8,
+                "included_markets": ["Match Winner", "Over/Under 2.5", "Both Teams to Score"],
+                "included_leagues": ["Premier League", "La Liga", "Bundesliga", "Serie A", "Ligue 1"],
+                "tolerance_factor": 1.0, "stop_threshold": 0.05,
+                "min_legs_fill_ratio": 0.7, "quality_vs_balance": 0.5, "consensus_vs_sources": 0.5,
+                "units": 1.5, "target_payout": 25.0, "run_daily_count": 2,
+                "consensus_shrinkage_k": 8, "min_source_edge": 1.5,
+                "max_single_leg_odds": 5.0, "tol_lower": 0.7, "tol_upper": 1.3,
+                "balance_decay": "gaussian", "min_pick_quality": 0.5,
+                "odds_movement_weight": 0.5, "odds_movement_strength_min": 0.03
+            },
+            "Aggressive": {
+                "target_odds": 6.0, "target_legs": 3, "max_legs_overflow": 2,
+                "consensus_floor": 40, "min_odds": 2.0,
+                "included_markets": ["Match Winner", "Over/Under 2.5", "Both Teams to Score", "Over/Under 3.5"],
+                "included_leagues": self.LEAGUES,
+                "tolerance_factor": 0.8, "stop_threshold": 0.1,
+                "min_legs_fill_ratio": 0.6, "quality_vs_balance": 0.3, "consensus_vs_sources": 0.4,
+                "units": 2.0, "target_payout": 50.0, "run_daily_count": 3,
+                "consensus_shrinkage_k": 5, "min_source_edge": 1.0,
+                "max_single_leg_odds": 10.0, "tol_lower": 0.6, "tol_upper": 1.5,
+                "balance_decay": "gaussian", "min_pick_quality": 0.4,
+                "odds_movement_weight": 0.7, "odds_movement_strength_min": 0.02
+            }
+        }
+        return {"profiles": profiles}
+
+    def get_builder_preview(self, cfg: BetSlipConfig) -> list[Any]:
+        """Build a preview slip from the deterministic demo match pool."""
+        rows: list[dict[str, Any]] = []
+        for match in self._matches:
+            rows.append({
+                "home": match.home,
+                "away": match.away,
+                "datetime": pd.to_datetime(match.datetime) if match.datetime else pd.NaT,
+                "sources": match.sources,
+                "result_url": match.result_url,
+                "league": match.league,
+                "cons_home": match.cons_home,
+                "cons_draw": match.cons_draw,
+                "cons_away": match.cons_away,
+                "cons_over_25": match.cons_over_25,
+                "cons_under_25": match.cons_under_25,
+                "cons_btts_yes": match.cons_btts_yes,
+                "cons_btts_no": match.cons_btts_no,
+                "cons_over_05": match.cons_over_05,
+                "cons_under_05": match.cons_under_05,
+                "cons_over_15": match.cons_over_15,
+                "cons_under_15": match.cons_under_15,
+                "cons_over_35": match.cons_over_35,
+                "cons_under_35": match.cons_under_35,
+                "cons_over_45": match.cons_over_45,
+                "cons_under_45": match.cons_under_45,
+                "cons_dc_1x": match.cons_dc_1x,
+                "cons_dc_12": match.cons_dc_12,
+                "cons_dc_x2": match.cons_dc_x2,
+                "odds_home": match.odds_home,
+                "odds_draw": match.odds_draw,
+                "odds_away": match.odds_away,
+                "odds_over_25": match.odds_over_25,
+                "odds_under_25": match.odds_under_25,
+                "odds_btts_yes": match.odds_btts_yes,
+                "odds_btts_no": match.odds_btts_no,
+                "odds_over_05": match.odds_over_05,
+                "odds_under_05": match.odds_under_05,
+                "odds_over_15": match.odds_over_15,
+                "odds_under_15": match.odds_under_15,
+                "odds_over_35": match.odds_over_35,
+                "odds_under_35": match.odds_under_35,
+                "odds_over_45": match.odds_over_45,
+                "odds_under_45": match.odds_under_45,
+                "odds_dc_1x": match.odds_dc_1x,
+                "odds_dc_12": match.odds_dc_12,
+                "odds_dc_x2": match.odds_dc_x2,
+            })
+
+        assistant = BetAssistant(":memory:")
+        assistant._df = pd.DataFrame(rows)
+        return assistant.build_slip(cfg)
+
+    def get_odds_history(self, match_id: int) -> dict[str, Any]:
+        """Return odds history for a match."""
+        if match_id < 0 or match_id >= len(self._matches):
+            raise ValueError(f"Match {match_id} not found")
+
+        match = self._matches[match_id]
+        history = self._odds_history.get(match_id, [])
+
+        snapshots = [{"timestamp": h["timestamp"], "odds": h["odds"]} for h in history]
+
+        # Calculate movement
+        movement = {}
+        if len(history) >= 2:
+            first = history[0]["odds"]
+            last = history[-1]["odds"]
+            for key in first:
+                if key in last:
+                    change = (last[key] - first[key]) / first[key] * 100
+                    if abs(change) > 2:
+                        movement[key] = "up" if change > 0 else "down"
+                    else:
+                        movement[key] = "stable"
+
+        return {
+            "match_id": match_id,
+            "match_name": f"{match.home} vs {match.away}",
+            "datetime": match.datetime or "",
+            "snapshots": snapshots,
+            "movement": movement
+        }
+
+    def get_all_movements(self) -> dict[str, Any]:
+        """Return movement summary for all future matches."""
+        result = {}
+        now = datetime.now()
+        for idx, match in enumerate(self._matches):
+            if match.datetime:
+                match_dt = datetime.fromisoformat(match.datetime)
+                if match_dt > now:
+                    history = self._odds_history.get(idx, [])
+                    if len(history) >= 2:
+                        first = history[0]["odds"]
+                        last = history[-1]["odds"]
+                        movement = {}
+                        for key in first:
+                            if key in last:
+                                change = (last[key] - first[key]) / first[key] * 100
+                                if abs(change) > 2:
+                                    movement[key] = "up" if change > 0 else "down"
+                                else:
+                                    movement[key] = "stable"
+                        if movement:
+                            result[str(idx)] = movement
+        return result
+
+    def get_significant_movements(self) -> dict[str, Any]:
+        """Return significant movements only."""
+        all_movements = self.get_all_movements()
+        result = {}
+        for match_id, movement in all_movements.items():
+            sig_count = sum(1 for v in movement.values() if v in ("up", "down"))
+            if sig_count > 0:
+                result[match_id] = movement
+        return result
+
+    # ── Helper methods (adapted from analytics.py) ──────────────────────────────
+
+    def _filter_slips(self, profiles: list[str] | None, date_from: str | None, date_to: str | None) -> list[BetSlip]:
+        filtered = self._slips
+        if profiles:
+            filtered = [s for s in filtered if s.profile in profiles]
+        if date_from:
+            filtered = [s for s in filtered if s.date_generated >= date_from]
+        if date_to:
+            filtered = [s for s in filtered if s.date_generated <= date_to]
+        return filtered
+
+    def _calculate_daily_summary(self, slips: list[BetSlip], date_from: str | None, date_to: str | None) -> list[dict]:
+        from collections import defaultdict
+        daily = defaultdict(lambda: {"slips": 0, "units": 0.0, "profit": 0.0, "won": 0, "total": 0})
+        for slip in slips:
+            date = slip.date_generated
+            daily[date]["slips"] += 1
+            daily[date]["units"] += slip.units
+            if slip.net_profit is not None:
+                daily[date]["profit"] += slip.net_profit
+            if slip.slip_status == SlipStatus.WON.value:
+                daily[date]["won"] += 1
+            daily[date]["total"] += 1
+
+        sorted_dates = sorted(daily.keys())
+        if date_from:
+            sorted_dates = [d for d in sorted_dates if d >= date_from]
+        if date_to:
+            sorted_dates = [d for d in sorted_dates if d <= date_to]
+
+        cumulative = 0.0
+        cumulative_bet = 0.0
+        result = []
+        for date in sorted_dates:
+            d = daily[date]
+            cumulative += d["profit"]
+            cumulative_bet += d["units"]
+            roi = (cumulative / cumulative_bet * 100) if cumulative_bet > 0 else 0.0
+            wr = (d["won"] / d["total"] * 100) if d["total"] > 0 else 0.0
+            result.append({
+                "date": date,
+                "slips_count": d["slips"],
+                "units_bet": round(d["units"], 2),
+                "net_profit": round(d["profit"], 2),
+                "cumulative_profit": round(cumulative, 2),
+                "cumulative_bet": round(cumulative_bet, 2),
+                "roi_percentage": round(roi, 2),
+                "win_rate": round(wr, 2)
+            })
+        return result
+
+    def _calculate_market_accuracy(self, slips: list[BetSlip]) -> list[dict]:
+        from collections import defaultdict
+        market_stats = defaultdict(lambda: {"won": 0, "lost": 0, "total": 0})
+        processed = set()
+        for slip in slips:
+            for leg in slip.legs:
+                fp = (leg.result_url, leg.market)
+                if fp in processed:
+                    continue
+                processed.add(fp)
+                m = market_stats[leg.market]
+                m["total"] += 1
+                if leg.status == Outcome.WON.value:
+                    m["won"] += 1
+                elif leg.status == Outcome.LOST.value:
+                    m["lost"] += 1
+        return [
+            {"market": m, "won": v["won"], "lost": v["lost"], "total": v["total"],
+             "accuracy": round(v["won"] / v["total"] * 100, 1) if v["total"] > 0 else 0.0}
+            for m, v in market_stats.items()
+        ]
+
+    def _pnl_by_market(self, slips: list[BetSlip]) -> list[dict]:
+        from collections import defaultdict
+        market_pnl = defaultdict(lambda: {"won": 0, "lost": 0, "profit": 0.0})
+        processed = set()
+        for slip in slips:
+            n_legs = max(len(slip.legs), 1)
+            per_leg_stake = slip.units / n_legs
+            for leg in slip.legs:
+                fp = (leg.result_url, leg.market)
+                if fp in processed:
+                    continue
+                processed.add(fp)
+                m = market_pnl[leg.market]
+                if leg.status == Outcome.WON.value:
+                    m["won"] += 1
+                    m["profit"] += (leg.odds - 1) * per_leg_stake
+                elif leg.status == Outcome.LOST.value:
+                    m["lost"] += 1
+                    m["profit"] -= per_leg_stake
+        return [
+            {"market": m, "won": v["won"], "lost": v["lost"], "net_profit": round(v["profit"], 2)}
+            for m, v in market_pnl.items()
+        ]
+
+    def _odds_distribution(self, slips: list[BetSlip]) -> list[dict]:
+        buckets = [
+            (1.0, 1.5, "1.0-1.5"), (1.5, 2.0, "1.5-2.0"), (2.0, 3.0, "2.0-3.0"),
+            (3.0, 5.0, "3.0-5.0"), (5.0, 10.0, "5.0-10.0"), (10.0, 100.0, "10.0+")
+        ]
+        bucket_stats = {label: {"count": 0, "wins": 0, "losses": 0, "sum_odds": 0.0, "sum_implied": 0.0} for _, _, label in buckets}
+        processed = set()
+        for slip in slips:
+            for leg in slip.legs:
+                fp = (leg.result_url, leg.market)
+                if fp in processed:
+                    continue
+                processed.add(fp)
+                for low, high, label in buckets:
+                    if low <= leg.odds < high or (label == "10.0+" and leg.odds >= 10.0):
+                        b = bucket_stats[label]
+                        b["count"] += 1
+                        b["sum_odds"] += leg.odds
+                        b["sum_implied"] += 1.0 / leg.odds if leg.odds > 0 else 0
+                        if leg.status == Outcome.WON.value:
+                            b["wins"] += 1
+                        elif leg.status == Outcome.LOST.value:
+                            b["losses"] += 1
+                        break
+        result = []
+        for low, high, label in buckets:
+            b = bucket_stats[label]
+            if b["count"] == 0:
+                continue
+            wr = round(b["wins"] / b["count"] * 100, 1)
+            implied = round(b["sum_implied"] / b["count"] * 100, 1)
+            result.append({
+                "range": label,
+                "count": b["count"],
+                "wins": b["wins"],
+                "losses": b["losses"],
+                "win_rate": wr,
+                "implied_win_rate": implied,
+                "avg_odds": round(b["sum_odds"] / b["count"], 2),
+                "edge": round(wr - implied, 1)
+            })
+        return result
+
+    def _calculate_correlation_data(self, slips: list[BetSlip]) -> list[dict]:
+        result = []
+        for slip in slips:
+            n_legs = len(slip.legs)
+            result.append({
+                "legs_count": n_legs,
+                "total_odds": slip.total_odds,
+                "units": slip.units,
+                "status": slip.slip_status,
+                "profit": slip.net_profit or 0.0
+            })
+        return result
+
+    def _profile_scatter(self, slips: list[BetSlip]) -> list[dict]:
+        from collections import defaultdict
+        profiles = defaultdict(lambda: {"total": 0, "won": 0, "sum_odds": 0.0, "sum_profit": 0.0})
+        for slip in slips:
+            p = profiles[slip.profile]
+            p["total"] += 1
+            p["sum_odds"] += slip.total_odds
+            if slip.slip_status == SlipStatus.WON.value:
+                p["won"] += 1
+                p["sum_profit"] += (slip.total_odds - 1) * slip.units
+            elif slip.slip_status == SlipStatus.LOST.value:
+                p["sum_profit"] -= slip.units
+        return [
+            {
+                "profile": p,
+                "avg_odds": round(d["sum_odds"] / d["total"], 2),
+                "win_rate": round(d["won"] / d["total"] * 100, 1),
+                "net_profit": round(d["sum_profit"], 2),
+                "volume": d["total"],
+                "break_even_win_rate": round(d["total"] / d["sum_odds"] * 100, 1) if d["sum_odds"] > 0 else 0.0
+            }
+            for p, d in profiles.items()
+        ]
+
+    def _calculate_stats(self, settled: list[BetSlip], all_slips: list[BetSlip]) -> dict[str, Any]:
+        if not settled:
+            return {
+                "total_settled": 0, "total_won_count": 0, "win_rate": 0.0,
+                "implied_win_rate": 0.0, "edge": 0.0, "total_units_bet": 0.0,
+                "gross_return": 0.0, "net_profit": 0.0, "roi_percentage": 0.0,
+                "avg_odds": 0.0, "avg_units": 0.0, "units_std": 0.0,
+                "pending_count": len([s for s in all_slips if s.slip_status == SlipStatus.PENDING.value]),
+                "sharpe_ratio": None, "kelly_suggested_units": 0.0,
+                "edge_trend": "neutral", "recent_edge_value": 0.0,
+                "biggest_win_units": None, "biggest_loss_units": None,
+                "best_day_pnl": None, "worst_day_pnl": None,
+                "current_streak": 0, "longest_win_streak": 0, "longest_loss_streak": 0,
+                "profit_factor": 0.0
+            }
+
+        total_settled = len(settled)
+        total_won = len([s for s in settled if s.slip_status == SlipStatus.WON.value])
+        win_rate = round(total_won / total_settled * 100, 1)
+
+        total_units = sum(s.units for s in settled)
+        gross_return = sum((s.total_odds - 1) * s.units for s in settled if s.slip_status == SlipStatus.WON.value)
+        net_profit = sum(s.net_profit or 0 for s in settled)
+        roi = round(net_profit / total_units * 100, 2) if total_units > 0 else 0.0
+        avg_odds = round(sum(s.total_odds for s in settled) / total_settled, 2)
+        avg_units = round(total_units / total_settled, 2)
+
+        # Implied win rate
+        implied_sum = sum(1.0 / s.total_odds for s in settled if s.total_odds > 0)
+        implied_wr = round(implied_sum / total_settled * 100, 1) if total_settled > 0 else 0.0
+        edge = round(win_rate - implied_wr, 1)
+
+        # Streaks
+        daily_pnl = {}
+        for slip in settled:
+            date = slip.date_generated
+            daily_pnl[date] = daily_pnl.get(date, 0) + (slip.net_profit or 0)
+        sorted_dates = sorted(daily_pnl.keys())
+        current_streak = 0
+        longest_win = 0
+        longest_loss = 0
+        temp_win = 0
+        temp_loss = 0
+        for date in sorted_dates:
+            pnl = daily_pnl[date]
+            if pnl > 0:
+                temp_win += 1
+                temp_loss = 0
+                longest_win = max(longest_win, temp_win)
+            elif pnl < 0:
+                temp_loss += 1
+                temp_win = 0
+                longest_loss = max(longest_loss, temp_loss)
+            else:
+                temp_win = 0
+                temp_loss = 0
+        if sorted_dates:
+            last_pnl = daily_pnl[sorted_dates[-1]]
+            if last_pnl > 0:
+                current_streak = temp_win
+            elif last_pnl < 0:
+                current_streak = -temp_loss
+
+        # Biggest win/loss
+        won_slips = [s for s in settled if s.slip_status == SlipStatus.WON.value]
+        lost_slips = [s for s in settled if s.slip_status == SlipStatus.LOST.value]
+        biggest_win = max((s.net_profit or 0) for s in won_slips) if won_slips else None
+        biggest_loss = min((s.net_profit or 0) for s in lost_slips) if lost_slips else None
+
+        # Best/worst day
+        best_day = max(daily_pnl.values()) if daily_pnl else None
+        worst_day = min(daily_pnl.values()) if daily_pnl else None
+
+        # Profit factor
+        gross_profit = sum(s.net_profit or 0 for s in won_slips)
+        gross_loss = abs(sum(s.net_profit or 0 for s in lost_slips))
+        profit_factor = round(gross_profit / gross_loss, 2) if gross_loss > 0 else 0.0
+
+        # Kelly
+        kelly = 0.0
+        if total_settled > 0 and implied_wr > 0:
+            kelly = round((win_rate / 100 - implied_wr / 100) / (avg_odds - 1) * 100, 2) if avg_odds > 1 else 0.0
+
+        return {
+            "total_settled": total_settled,
+            "total_won_count": total_won,
+            "win_rate": win_rate,
+            "implied_win_rate": implied_wr,
+            "edge": edge,
+            "total_units_bet": round(total_units, 2),
+            "gross_return": round(gross_return, 2),
+            "net_profit": round(net_profit, 2),
+            "roi_percentage": roi,
+            "avg_odds": avg_odds,
+            "avg_units": avg_units,
+            "units_std": 0.0,
+            "pending_count": len([s for s in all_slips if s.slip_status == SlipStatus.PENDING.value]),
+            "sharpe_ratio": None,
+            "kelly_suggested_units": kelly,
+            "edge_trend": "neutral",
+            "recent_edge_value": 0.0,
+            "biggest_win_units": biggest_win,
+            "biggest_loss_units": biggest_loss,
+            "best_day_pnl": best_day,
+            "worst_day_pnl": worst_day,
+            "current_streak": current_streak,
+            "longest_win_streak": longest_win,
+            "longest_loss_streak": longest_loss,
+            "profit_factor": profit_factor
+        }
+
+    def _market_breakdown(self, slips: list[BetSlip]) -> list[dict]:
+        from collections import defaultdict
+        data = defaultdict(lambda: {"legs": 0, "won": 0, "lost": 0, "sum_odds": 0.0, "sum_implied": 0.0, "net_profit": 0.0})
+        processed = set()
+        for slip in slips:
+            n_legs = max(len(slip.legs), 1)
+            per_leg_stake = slip.units / n_legs
+            for leg in slip.legs:
+                fp = (leg.result_url, leg.market)
+                if fp in processed:
+                    continue
+                processed.add(fp)
+                m = data[leg.market]
+                m["legs"] += 1
+                m["sum_odds"] += leg.odds
+                m["sum_implied"] += 1.0 / leg.odds if leg.odds > 0 else 0
+                if leg.status == Outcome.WON.value:
+                    m["won"] += 1
+                    m["net_profit"] += (leg.odds - 1) * per_leg_stake
+                elif leg.status == Outcome.LOST.value:
+                    m["lost"] += 1
+                    m["net_profit"] -= per_leg_stake
+        result = []
+        for m, d in data.items():
+            total = d["legs"]
+            wr = round(d["won"] / total * 100, 1) if total else 0.0
+            implied = round(d["sum_implied"] / total * 100, 1) if total else 0.0
+            result.append({
+                "market": m, "legs": total, "won": d["won"], "lost": d["lost"],
+                "win_rate": wr, "implied_win_rate": implied, "edge": round(wr - implied, 1),
+                "avg_odds": round(d["sum_odds"] / total, 2) if total else 0.0,
+                "net_profit": round(d["net_profit"], 2)
+            })
+        return sorted(result, key=lambda x: x["edge"], reverse=True)
+
+    def _league_breakdown(self, slips: list[BetSlip]) -> list[dict]:
+        from collections import defaultdict
+        data = defaultdict(lambda: {"legs": 0, "won": 0, "lost": 0, "sum_odds": 0.0, "sum_implied": 0.0, "net_profit": 0.0})
+        processed = set()
+        for slip in slips:
+            n_legs = max(len(slip.legs), 1)
+            per_leg_stake = slip.units / n_legs
+            for leg in slip.legs:
+                fp = (leg.result_url, leg.market)
+                if fp in processed:
+                    continue
+                processed.add(fp)
+                lg = leg.league or "Unknown"
+                m = data[lg]
+                m["legs"] += 1
+                m["sum_odds"] += leg.odds
+                m["sum_implied"] += 1.0 / leg.odds if leg.odds > 0 else 0
+                if leg.status == Outcome.WON.value:
+                    m["won"] += 1
+                    m["net_profit"] += (leg.odds - 1) * per_leg_stake
+                elif leg.status == Outcome.LOST.value:
+                    m["lost"] += 1
+                    m["net_profit"] -= per_leg_stake
+        result = []
+        for lg, d in data.items():
+            total = d["legs"]
+            wr = round(d["won"] / total * 100, 1) if total else 0.0
+            implied = round(d["sum_implied"] / total * 100, 1) if total else 0.0
+            result.append({
+                "league": lg, "legs": total, "won": d["won"], "lost": d["lost"],
+                "win_rate": wr, "implied_win_rate": implied, "edge": round(wr - implied, 1),
+                "avg_odds": round(d["sum_odds"] / total, 2) if total else 0.0,
+                "net_profit": round(d["net_profit"], 2)
+            })
+        return sorted(result, key=lambda x: x["edge"], reverse=True)
+
+    def _calculate_rolling_edge(self, slips: list[BetSlip], window: int) -> list[dict]:
+        from collections import defaultdict
+        daily = defaultdict(lambda: {"won": 0, "total": 0, "sum_implied": 0.0})
+        processed = set()
+        for slip in slips:
+            date = slip.date_generated
+            for leg in slip.legs:
+                fp = (leg.result_url, leg.market)
+                if fp in processed:
+                    continue
+                processed.add(fp)
+                d = daily[date]
+                d["total"] += 1
+                d["sum_implied"] += 1.0 / leg.odds if leg.odds > 0 else 0
+                if leg.status == Outcome.WON.value:
+                    d["won"] += 1
+        sorted_dates = sorted(daily.keys())
+        result = []
+        for i, date in enumerate(sorted_dates):
+            start = max(0, i - window + 1)
+            window_dates = sorted_dates[start:i+1]
+            total_won = sum(daily[d]["won"] for d in window_dates)
+            total_legs = sum(daily[d]["total"] for d in window_dates)
+            total_implied = sum(daily[d]["sum_implied"] for d in window_dates)
+            if total_legs > 0:
+                wr = round(total_won / total_legs * 100, 1)
+                implied = round(total_implied / total_legs * 100, 1)
+                result.append({
+                    "date": date,
+                    "rolling_edge": round(wr - implied, 1),
+                    "rolling_win_rate": wr,
+                    "rolling_implied": implied,
+                    "sample_size": total_legs
+                })
+        return result
+
+    def _calculate_drawdown(self, history: list[dict]) -> list[dict]:
+        if not history:
+            return []
+        peak = 0.0
+        result = []
+        for day in history:
+            cum = day["cumulative_profit"]
+            if cum > peak:
+                peak = cum
+            result.append({
+                "date": day["date"],
+                "drawdown": round(cum - peak, 2),
+                "peak": round(peak, 2),
+                "cumulative_profit": cum
+            })
+        return result
+
+    def _calculate_return_distribution(self, slips: list[BetSlip]) -> dict[str, Any] | None:
+        if not slips:
+            return None
+        profits = [s.net_profit or 0 for s in slips]
+        if not profits:
+            return None
+        import math
+        mean = sum(profits) / len(profits)
+        sorted_profits = sorted(profits)
+        median = sorted_profits[len(sorted_profits) // 2]
+        min_p, max_p = min(profits), max(profits)
+        bin_width = max(0.5, (max_p - min_p) / 10) if max_p != min_p else 1.0
+        bins = []
+        for i in range(10):
+            low = min_p + i * bin_width
+            high = low + bin_width
+            count = sum(1 for p in profits if low <= p < high) or (1 if i == 9 and max_p == high else 0)
+            bins.append({
+                "range": f"{low:.1f}",
+                "range_end": f"{high:.1f}",
+                "count": count,
+                "is_positive": low >= 0
+            })
+        return {"bins": bins, "mean": round(mean, 2), "median": round(median, 2)}
+
+    def _calculate_time_patterns(self, slips: list[BetSlip]) -> dict[str, Any] | None:
+        from collections import defaultdict
+        dow = defaultdict(lambda: {"total": 0, "won": 0})
+        hour = defaultdict(lambda: {"total": 0, "won": 0})
+        for slip in slips:
+            try:
+                dt = datetime.strptime(slip.date_generated, "%Y-%m-%d")
+                dow[dt.strftime("%A")]["total"] += 1
+                if slip.slip_status == SlipStatus.WON.value:
+                    dow[dt.strftime("%A")]["won"] += 1
+            except ValueError:
+                pass
+        dow_order = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+        dow_result = []
+        for day in dow_order:
+            if day in dow:
+                d = dow[day]
+                dow_result.append({"key": day, "total": d["total"], "won": d["won"],
+                                   "win_rate": round(d["won"] / d["total"] * 100, 1) if d["total"] > 0 else 0.0})
+        return {"day_of_week": dow_result, "hour": []}
+
+    def _correlation_matrix(self, slips: list[BetSlip]) -> dict[str, Any]:
+        from collections import defaultdict
+        data = defaultdict(lambda: defaultdict(lambda: {"won": 0, "total": 0, "sum_implied": 0.0}))
+        leagues = set()
+        markets = set()
+        processed = set()
+        for slip in slips:
+            for leg in slip.legs:
+                fp = (leg.result_url, leg.market)
+                if fp in processed:
+                    continue
+                processed.add(fp)
+                lg = leg.league or "Unknown"
+                mkt = leg.market
+                leagues.add(lg)
+                markets.add(mkt)
+                cell = data[lg][mkt]
+                cell["total"] += 1
+                cell["sum_implied"] += 1.0 / leg.odds if leg.odds > 0 else 0
+                if leg.status == Outcome.WON.value:
+                    cell["won"] += 1
+        matrix = {}
+        for lg in sorted(leagues):
+            matrix[lg] = {}
+            for mkt in sorted(markets):
+                if mkt in data[lg]:
+                    d = data[lg][mkt]
+                    wr = round(d["won"] / d["total"] * 100, 1) if d["total"] > 0 else 0.0
+                    implied = round(d["sum_implied"] / d["total"] * 100, 1) if d["total"] > 0 else 0.0
+                    matrix[lg][mkt] = {"win_rate": wr, "edge": round(wr - implied, 1), "total": d["total"]}
+        return {"leagues": sorted(leagues), "markets": sorted(markets), "matrix": matrix}
+
+    def _profit_attribution(self, slips: list[BetSlip]) -> dict[str, Any]:
+        """Sequential Shapley approximation for profit attribution."""
+        import pandas as pd
+        records = []
+        for slip in slips:
+            n_legs = max(len(slip.legs), 1)
+            per_leg_stake = slip.units / n_legs
+            slip_profit = 0.0
+            for leg in slip.legs:
+                leg_profit = (leg.odds - 1) * per_leg_stake if leg.status == Outcome.WON.value else -per_leg_stake
+                slip_profit += leg_profit
+                records.append({
+                    "slip_id": slip.slip_id,
+                    "leg_result_url": leg.result_url,
+                    "market": leg.market,
+                    "league": leg.league or "Unknown",
+                    "odds": leg.odds,
+                    "bet_type": f"{len(slip.legs)}-leg" if len(slip.legs) < 5 else "5+",
+                    "stake": per_leg_stake,
+                    "profile": slip.profile,
+                    "date_generated": slip.date_generated,
+                    "profit": leg_profit,
+                    "slip_profit": slip_profit,
+                })
+        if not records:
+            return {"total_profit": 0.0, "components": []}
+        df = pd.DataFrame(records)
+        total_profit = df["slip_profit"].iloc[0] if not df.empty else 0.0
+        df = df.drop_duplicates(subset=["leg_result_url", "market"])
+        def odds_bucket(o):
+            if o < 1.5: return "<1.5"
+            elif o < 2.0: return "1.5-2.0"
+            elif o < 3.5: return "2.0-3.5"
+            elif o < 7.0: return "3.5-7.0"
+            else: return "7.0+"
+        df["odds_bucket"] = df["odds"].apply(odds_bucket)
+        df["timing_bucket"] = "Pre-match (>24h)"
+        dimensions = [
+            ("Market Selection", "market"),
+            ("League Selection", "league"),
+            ("Odds Range", "odds_bucket"),
+            ("Bet Type", "bet_type"),
+            ("Stake Sizing", "stake"),
+            ("Timing", "timing_bucket"),
+            ("Profile", "profile"),
+        ]
+        components = []
+        running_total = 0.0
+        prev_avg = 0.0
+        for name, col in dimensions:
+            grouped = df.groupby(col).agg(avg_profit=("profit", "mean"), count=("profit", "count")).reset_index()
+            weighted_avg = (grouped["avg_profit"] * grouped["count"]).sum() / grouped["count"].sum()
+            contribution = weighted_avg - prev_avg
+            running_total += contribution
+            components.append({
+                "name": name,
+                "value": round(contribution, 2),
+                "percentage": round(contribution / total_profit * 100, 1) if total_profit != 0 else 0.0,
+                "sub_components": [
+                    {"name": row[col], "value": round(row["avg_profit"], 2), "count": int(row["count"])}
+                    for _, row in grouped.iterrows()
+                ],
+            })
+            prev_avg = weighted_avg
+        residual = total_profit - running_total
+        components.append({
+            "name": "Residual (Noise)",
+            "value": round(residual, 2),
+            "percentage": round(residual / total_profit * 100, 1) if total_profit != 0 else 0.0,
+            "sub_components": [],
+        })
+        return {"total_profit": round(total_profit, 2), "components": components}
+
+
+# Singleton instance
+demo_provider = DemoDataProvider()
+
+
+def get_demo_provider() -> DemoDataProvider:
+    return demo_provider

--- a/bet_dashboard/backend/routers/analytics.py
+++ b/bet_dashboard/backend/routers/analytics.py
@@ -8,9 +8,12 @@ from core.analytics_utils import (
     calculate_market_accuracy,
     calculate_rolling_edge,
 )
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from utils.json_utils import sanitize_floats
 from utils.profile_utils import get_profile_params
+
+# Demo data provider
+from fixtures.demo_data import get_demo_provider
 
 router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 
@@ -184,6 +187,134 @@ def _league_breakdown(slips) -> list[dict]:
     return sorted(result, key=lambda x: x["edge"], reverse=True)
 
 
+# ── Profit Attribution (sequential Shapley approximation) ───────────────────
+
+
+def _profit_attribution(slips) -> dict:
+    """
+    Sequential Shapley approximation for profit attribution.
+    Order: Market → League → Odds Range → Bet Type → Stake Sizing → Timing → Profile → Residual
+    """
+    import pandas as pd
+    from collections import defaultdict
+
+    # Collect all legs with slip-level info
+    records = []
+    for slip in slips:
+        s_status = _get_status_value(slip.slip_status)
+        if s_status not in ("Won", "Lost"):
+            continue
+        n_legs = max(len(slip.legs), 1)
+        per_leg_stake = slip.units / n_legs
+        slip_profit = 0.0
+        for leg in slip.legs:
+            l_status = _get_status_value(leg.status)
+            if l_status not in ("Won", "Lost"):
+                continue
+            leg_profit = (leg.odds - 1) * per_leg_stake if l_status == "Won" else -per_leg_stake
+            slip_profit += leg_profit
+            records.append({
+                "slip_id": slip.slip_id,
+                "leg_result_url": leg.result_url,
+                "market": str(leg.market),
+                "league": getattr(leg, "league", None) or "Unknown",
+                "odds": leg.odds,
+                "bet_type": f"{len(slip.legs)}-leg" if len(slip.legs) < 5 else "5+",
+                "stake": per_leg_stake,
+                "kelly_stake": per_leg_stake,  # placeholder; would need Kelly calc
+                "profile": slip.profile,
+                "date_generated": slip.date_generated,
+                "profit": leg_profit,
+                "slip_profit": slip_profit,
+            })
+
+    if not records:
+        return {
+            "total_profit": 0.0,
+            "components": [],
+        }
+
+    df = pd.DataFrame(records)
+    total_profit = df["slip_profit"].iloc[0] if not df.empty else 0.0
+
+    # Deduplicate legs
+    df = df.drop_duplicates(subset=["leg_result_url", "market"])
+
+    # Define buckets
+    def odds_bucket(o):
+        if o < 1.5:
+            return "<1.5"
+        elif o < 2.0:
+            return "1.5-2.0"
+        elif o < 3.5:
+            return "2.0-3.5"
+        elif o < 7.0:
+            return "3.5-7.0"
+        else:
+            return "7.0+"
+
+    def timing_bucket(date_str):
+        # Simplified: assume all are pre-match for now; would need kickoff time
+        return "Pre-match (>24h)"
+
+    df["odds_bucket"] = df["odds"].apply(odds_bucket)
+    df["timing_bucket"] = df["date_generated"].apply(timing_bucket)
+
+    # Sequential attribution order
+    dimensions = [
+        ("Market Selection", "market"),
+        ("League Selection", "league"),
+        ("Odds Range", "odds_bucket"),
+        ("Bet Type", "bet_type"),
+        ("Stake Sizing", "stake"),  # simplified
+        ("Timing", "timing_bucket"),
+        ("Profile", "profile"),
+    ]
+
+    components = []
+    running_total = 0.0
+    prev_avg = 0.0
+
+    for name, col in dimensions:
+        # Group by dimension and compute average profit per leg
+        grouped = df.groupby(col).agg(
+            avg_profit=("profit", "mean"),
+            count=("profit", "count"),
+        ).reset_index()
+        # Weight by frequency
+        weighted_avg = (grouped["avg_profit"] * grouped["count"]).sum() / grouped["count"].sum()
+        contribution = weighted_avg - prev_avg
+        running_total += contribution
+        components.append({
+            "name": name,
+            "value": round(contribution, 2),
+            "percentage": round(contribution / total_profit * 100, 1) if total_profit != 0 else 0.0,
+            "sub_components": [
+                {
+                    "name": row[col],
+                    "value": round(row["avg_profit"], 2),
+                    "count": int(row["count"]),
+                }
+                for _, row in grouped.iterrows()
+            ],
+        })
+        prev_avg = weighted_avg
+
+    # Residual
+    residual = total_profit - running_total
+    components.append({
+        "name": "Residual (Noise)",
+        "value": round(residual, 2),
+        "percentage": round(residual / total_profit * 100, 1) if total_profit != 0 else 0.0,
+        "sub_components": [],
+    })
+
+    return {
+        "total_profit": round(total_profit, 2),
+        "components": components,
+    }
+
+
 # ── Existing helpers (unchanged) ───────────────────────────────────────────────
 
 
@@ -267,7 +398,13 @@ def get_analytics(
     profiles: list[str] | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    data_source: str = Query("live", pattern="^(live|demo)$"),
 ):
+    # Route to demo data provider if requested
+    if data_source == "demo":
+        demo_provider = get_demo_provider()
+        return sanitize_floats(demo_provider.get_analytics(profiles, date_from, date_to))
+
     logic = _get(request).logic
 
     if profiles is None:

--- a/bet_dashboard/backend/routers/builder.py
+++ b/bet_dashboard/backend/routers/builder.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import math
 
 from core.schemas import BetSlipConfigIn, ExcludeUrlIn
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from utils.json_utils import sanitize_floats
 
 from bet_framework.core.Slip import BetSlipConfig
+from fixtures.demo_data import get_demo_provider
 
 router = APIRouter(prefix="/api/builder", tags=["builder"])
 
@@ -45,12 +46,16 @@ def _to_config(body: BetSlipConfigIn) -> BetSlipConfig:
 
 
 @router.post("/preview")
-def preview(request: Request, body: BetSlipConfigIn):
+def preview(request: Request, body: BetSlipConfigIn, data_source: str = Query("live", pattern="^(live|demo)$")):
     app = _get(request)
     cfg = _to_config(body)
-    legs = app.build_preview(cfg)
+    if data_source == "demo":
+        legs = get_demo_provider().get_builder_preview(cfg)
+        pending_urls: list[str] = []
+    else:
+        legs = app.build_preview(cfg)
+        pending_urls = list(app.logic.get_pending_urls())
     total_odds = math.prod(leg.odds for leg in legs) if legs else 1.0
-    pending_urls = list(app.logic.get_pending_urls())
 
     response_data = {
         "total_odds": round(total_odds, 4),
@@ -92,8 +97,10 @@ def get_excluded(request: Request):
 
 
 @router.get("/excluded/details")
-def get_excluded_details(request: Request):
+def get_excluded_details(request: Request, data_source: str = Query("live", pattern="^(live|demo)$")):
     """Get detailed info about manually excluded matches only."""
+    if data_source == "demo":
+        return {"excluded": []}
     app = _get(request)
     # Only return manually excluded URLs
     excluded_urls = app.get_manual_excluded()
@@ -148,6 +155,8 @@ def clear_excluded(request: Request):
 
 
 @router.get("/leagues")
-def get_leagues(request: Request):
+def get_leagues(request: Request, data_source: str = Query("live", pattern="^(live|demo)$")):
+    if data_source == "demo":
+        return get_demo_provider().LEAGUES
     app = _get(request)
     return app.get_leagues()

--- a/bet_dashboard/backend/routers/matches.py
+++ b/bet_dashboard/backend/routers/matches.py
@@ -5,6 +5,9 @@ import math
 from core.market_config import CONSENSUS_COLUMNS, MARKET_DEFINITIONS
 from fastapi import APIRouter, Query, Request
 
+# Demo data provider
+from fixtures.demo_data import get_demo_provider
+
 router = APIRouter(prefix="/api/matches", tags=["matches"])
 
 
@@ -41,7 +44,14 @@ def get_matches(
     min_consensus: int | None = Query(None, ge=0, le=100),
     min_odds: float | None = Query(None, ge=1.0, le=50.0),
     only_significant_movement: bool = Query(False),
+    data_source: str = Query("live", pattern="^(live|demo)$"),
 ):
+    # Route to demo data provider if requested
+    if data_source == "demo":
+        demo_provider = get_demo_provider()
+        return demo_provider.get_matches(page, page_size, search, date_from, date_to,
+                                         sort_by, sort_dir, min_consensus, min_odds, only_significant_movement)
+
     logic = _get(request).logic
     df = logic.filter_matches(
         search_text=search or None,

--- a/bet_dashboard/backend/routers/odds_history.py
+++ b/bet_dashboard/backend/routers/odds_history.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from core.schemas import OddsHistoryOut, OddsMovementSummary, OddsSnapshotOut
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from bet_dashboard.backend.core.market_config import MARKET_DEFINITIONS
+
+# Demo data provider
+from fixtures.demo_data import get_demo_provider
 
 router = APIRouter(prefix="/api/odds-history", tags=["odds-history"])
 
@@ -16,8 +19,10 @@ def _get(request: Request):
 
 
 @router.get("/movements/all")
-def get_all_movements(request: Request) -> dict[str, OddsMovementSummary]:
+def get_all_movements(request: Request, data_source: str = Query("live", pattern="^(live|demo)$")) -> dict[str, OddsMovementSummary]:
     """Get movement summary for all future matches."""
+    if data_source == "demo":
+        return get_demo_provider().get_all_movements()
     logic = _get(request).logic
     df = logic.match_df
 
@@ -46,8 +51,11 @@ def get_all_movements(request: Request) -> dict[str, OddsMovementSummary]:
 
 
 @router.get("/movements/significant")
-def get_significant_movements(request: Request) -> dict:
+def get_significant_movements(request: Request, data_source: str = Query("live", pattern="^(live|demo)$")) -> dict:
     """Movement data with strength metrics, filtered to significant only."""
+    if data_source == "demo":
+        raw = get_demo_provider().get_significant_movements()
+        return {match_id: {key: {"direction": direction, "change_pct": 0.0, "significant": direction in ("up", "down")} for key, direction in movement.items()} for match_id, movement in raw.items()}
     logic = _get(request).logic
     df = logic.match_df
     if df.empty:
@@ -74,8 +82,10 @@ def get_significant_movements(request: Request) -> dict:
 
 
 @router.get("/{match_id}", response_model=OddsHistoryOut)
-def get_match_odds_history(request: Request, match_id: int):
+def get_match_odds_history(request: Request, match_id: int, data_source: str = Query("live", pattern="^(live|demo)$")):
     """Get full odds history for a specific match."""
+    if data_source == "demo":
+        return get_demo_provider().get_odds_history(match_id)
     logic = _get(request).logic
 
     # Get match info from the database
@@ -110,8 +120,10 @@ def get_match_odds_history(request: Request, match_id: int):
 
 
 @router.get("/{match_id}/movement", response_model=OddsMovementSummary)
-def get_match_movement(request: Request, match_id: int):
+def get_match_movement(request: Request, match_id: int, data_source: str = Query("live", pattern="^(live|demo)$")):
     """Get just the movement summary for a match."""
+    if data_source == "demo":
+        return get_demo_provider().get_all_movements().get(str(match_id), {})
     logic = _get(request).logic
     movement = logic.get_odds_movement(match_id)
 

--- a/bet_dashboard/backend/routers/profiles.py
+++ b/bet_dashboard/backend/routers/profiles.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from core.config_helpers import _config_to_yaml_dict
 from core.schemas import ProfileIn
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from bet_framework.core.Slip import BetSlipConfig
+
+# Demo data provider
+from fixtures.demo_data import get_demo_provider
 
 router = APIRouter(prefix="/api/profiles", tags=["profiles"])
 
@@ -14,7 +17,12 @@ def _get(request: Request):
 
 
 @router.get("")
-def list_profiles(request: Request):
+def list_profiles(request: Request, data_source: str = Query("live", pattern="^(live|demo)$")):
+    # Route to demo data provider if requested
+    if data_source == "demo":
+        demo_provider = get_demo_provider()
+        return demo_provider.get_profiles()
+
     app = _get(request)
     profiles = app.settings.get("profiles") or {}
     return {"profiles": profiles}

--- a/bet_dashboard/backend/routers/slips.py
+++ b/bet_dashboard/backend/routers/slips.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from core.market_config import ALLOWED_MARKETS
 from core.schemas import ManualLegIn, SlipIn
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from utils.json_utils import sanitize_floats
 from utils.profile_utils import get_profile_params
 
 from bet_framework.core.Slip import CandidateLeg
 from bet_framework.core.types import MarketLabel, MarketType
 from bet_framework.core.utils import is_valid_url
+
+# Demo data provider
+from fixtures.demo_data import get_demo_provider
 
 router = APIRouter(prefix="/api/slips", tags=["slips"])
 
@@ -221,7 +224,15 @@ def get_slips(
     date_to: str | None = None,
     hide_settled: str | None = None,
     live_only: str | None = None,
+    data_source: str = Query("live", pattern="^(live|demo)$"),
 ):
+    # Route to demo data provider if requested
+    if data_source == "demo":
+        demo_provider = get_demo_provider()
+        return sanitize_floats(demo_provider.get_slips(profiles, date_from, date_to,
+                                                        to_bool(hide_settled) if hide_settled else False,
+                                                        to_bool(live_only) if live_only else False))
+
     app = _get(request)
     logic = app.logic
 

--- a/bet_dashboard/frontend/src/api/data.ts
+++ b/bet_dashboard/frontend/src/api/data.ts
@@ -5,17 +5,22 @@ import type {
     SlipsPage, ManualLegIn,
     AnalyticsData,
     ServicesData,
+    MatchesPage,
+    OddsHistory,
+    DataSource,
 } from '../types';
 
 // ── Builder ──────────────────────────────────────────────────────────────────
 
-export async function fetchPreview(cfg: BuilderConfig): Promise<PreviewResult> {
-    const res = await client.post<PreviewResult>('/builder/preview', cfg);
+export async function fetchPreview(cfg: BuilderConfig, dataSource: DataSource = 'live'): Promise<PreviewResult> {
+    const res = await client.post<PreviewResult>('/builder/preview', cfg, {
+        params: { data_source: dataSource },
+    });
     return res.data;
 }
 
-export async function fetchLeagues(): Promise<string[]> {
-    const res = await client.get<string[]>('/builder/leagues');
+export async function fetchLeagues(dataSource: DataSource = 'live'): Promise<string[]> {
+    const res = await client.get<string[]>('/builder/leagues', { params: { data_source: dataSource } });
     return res.data;
 }
 
@@ -31,8 +36,8 @@ export interface ExcludedMatch {
     reason: string;
 }
 
-export async function fetchExcludedDetails(): Promise<ExcludedMatch[]> {
-    const res = await client.get<{ excluded: ExcludedMatch[] }>('/builder/excluded/details');
+export async function fetchExcludedDetails(dataSource: DataSource = 'live'): Promise<ExcludedMatch[]> {
+    const res = await client.get<{ excluded: ExcludedMatch[] }>('/builder/excluded/details', { params: { data_source: dataSource } });
     return res.data.excluded;
 }
 
@@ -52,8 +57,8 @@ export async function clearExcluded(): Promise<void> {
 
 // ── Profiles ─────────────────────────────────────────────────────────────────
 
-export async function fetchProfiles(): Promise<ProfilesMap> {
-    const res = await client.get<{ profiles: ProfilesMap }>('/profiles');
+export async function fetchProfiles(dataSource: DataSource = 'live'): Promise<ProfilesMap> {
+    const res = await client.get<{ profiles: ProfilesMap }>('/profiles', { params: { data_source: dataSource } });
     return res.data.profiles;
 }
 
@@ -70,6 +75,7 @@ export async function deleteProfile(name: string): Promise<void> {
 export async function fetchSlips(params: {
     profiles?: string[]; date_from?: string; date_to?: string;
     hide_settled?: boolean; live_only?: boolean;
+    data_source?: DataSource;
 }): Promise<SlipsPage> {
     const res = await client.get<SlipsPage>('/slips', { params });
     return res.data;
@@ -101,15 +107,47 @@ export async function generateSlips(): Promise<{ generated: number; by_profile: 
 
 export async function fetchAnalytics(params: {
     profiles?: string[]; date_from?: string; date_to?: string;
+    data_source?: DataSource;
 }): Promise<AnalyticsData> {
     const res = await client.get<AnalyticsData>('/analytics', { params });
     return res.data;
 }
 
+// ── Matches ──────────────────────────────────────────────────────────────────
+
+export async function fetchMatches(params: {
+    page?: number; page_size?: number; search?: string;
+    date_from?: string; date_to?: string;
+    sort_by?: string; sort_dir?: string;
+    min_consensus?: number; min_odds?: number;
+    only_significant_movement?: boolean;
+    data_source?: DataSource;
+}): Promise<MatchesPage> {
+    const res = await client.get<MatchesPage>('/matches', { params });
+    return res.data;
+}
+
+// ── Odds History ─────────────────────────────────────────────────────────────
+
+export async function fetchOddsHistory(matchId: number, dataSource: DataSource = 'live'): Promise<OddsHistory> {
+    const res = await client.get<OddsHistory>(`/odds-history/${matchId}`, { params: { data_source: dataSource } });
+    return res.data;
+}
+
+export async function fetchAllMovements(dataSource: DataSource = 'live'): Promise<Record<string, any>> {
+    const res = await client.get<Record<string, any>>('/odds-history/movements/all', { params: { data_source: dataSource } });
+    return res.data;
+}
+
+export async function fetchSignificantMovements(dataSource: DataSource = 'live'): Promise<Record<string, any>> {
+    const res = await client.get<Record<string, any>>('/odds-history/movements/significant', { params: { data_source: dataSource } });
+    return res.data;
+}
+
 // ── Services ─────────────────────────────────────────────────────────────────
 
-export async function fetchServices(): Promise<ServicesData> {
-    const res = await client.get<ServicesData>('/services');
+export async function fetchServices(dataSource: DataSource = 'live'): Promise<ServicesData> {
+    const res = await client.get<ServicesData>('/services', { params: { data_source: dataSource } });
     return res.data;
 }
 

--- a/bet_dashboard/frontend/src/api/matches.ts
+++ b/bet_dashboard/frontend/src/api/matches.ts
@@ -1,5 +1,6 @@
 import client from './client';
 import type { MatchesPage } from '../types';
+import type { DataSource } from '../types';
 
 export async function fetchMatches(params: {
     page: number; page_size: number;
@@ -8,6 +9,7 @@ export async function fetchMatches(params: {
     min_consensus?: number | null;
     min_odds?: number | null;
     only_significant_movement?: boolean;
+    data_source?: DataSource;
 }): Promise<MatchesPage> {
     const res = await client.get<MatchesPage>('/matches', { params });
     return res.data;

--- a/bet_dashboard/frontend/src/api/oddsHistory.ts
+++ b/bet_dashboard/frontend/src/api/oddsHistory.ts
@@ -1,5 +1,6 @@
 import client from './client';
 import type { OddsHistory, OddsMovementSummary, MarketMovementDetail } from '../types';
+import type { DataSource } from '../types';
 
 /**
  * Get full odds history for a specific match
@@ -20,14 +21,18 @@ export async function getMatchMovement(matchId: number): Promise<OddsMovementSum
 /**
  * Get movement summary for all future matches
  */
-export async function getAllMovements(): Promise<Record<string, OddsMovementSummary>> {
-    const response = await client.get<Record<string, OddsMovementSummary>>('/odds-history/movements/all');
+export async function getAllMovements(dataSource: DataSource = 'live'): Promise<Record<string, OddsMovementSummary>> {
+    const response = await client.get<Record<string, OddsMovementSummary>>('/odds-history/movements/all', {
+        params: { data_source: dataSource },
+    });
     return response.data;
 }
 
 export type SignificantMovements = Record<string, Record<string, MarketMovementDetail>>;
 
-export async function getSignificantMovements(): Promise<SignificantMovements> {
-    const { data } = await client.get<SignificantMovements>('/odds-history/movements/significant');
+export async function getSignificantMovements(dataSource: DataSource = 'live'): Promise<SignificantMovements> {
+    const { data } = await client.get<SignificantMovements>('/odds-history/movements/significant', {
+        params: { data_source: dataSource },
+    });
     return data;
 }

--- a/bet_dashboard/frontend/src/components/Layout.tsx
+++ b/bet_dashboard/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, createContext, useContext } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { pullDb } from '../api/data';
 
@@ -11,9 +11,27 @@ const LINKS = [
     { to: '/odds-alert', label: 'Odds Alert' },
 ];
 
+export type DataSource = 'live' | 'demo';
+
+interface DataSourceContextValue {
+    dataSource: DataSource;
+    setDataSource: (source: DataSource) => void;
+}
+
+const DataSourceContext = createContext<DataSourceContextValue | null>(null);
+
+export function useDataSource() {
+    const context = useContext(DataSourceContext);
+    if (!context) {
+        throw new Error('useDataSource must be used within a DataSourceProvider');
+    }
+    return context;
+}
+
 export interface GlobalFilters {
     dateFrom: string;
     dateTo: string;
+    dataSource: DataSource;
 }
 
 interface Props {
@@ -28,6 +46,21 @@ export default function Layout({ children, lastPull, onRefresh, onMatchesUpdated
     const [dateFrom, setDateFrom] = useState('');
     const [dateTo, setDateTo] = useState('');
     const [pulling, setPulling] = useState(false);
+    
+    // Data source state with localStorage persistence
+    const [dataSource, setDataSource] = useState<DataSource>(() => {
+        if (typeof window !== 'undefined') {
+            const stored = localStorage.getItem('bet-assistant.dataSource');
+            if (stored === 'demo' || stored === 'live') {
+                return stored;
+            }
+        }
+        return 'live';
+    });
+
+    useEffect(() => {
+        localStorage.setItem('bet-assistant.dataSource', dataSource);
+    }, [dataSource]);
 
     const showFilters = location.pathname === '/' ||
         location.pathname === '/builder' ||
@@ -95,10 +128,30 @@ export default function Layout({ children, lastPull, onRefresh, onMatchesUpdated
                                 {lastPull}
                             </span>
                         )}
+                        {/* Data Source Toggle */}
+                        <div className="flex items-center gap-2" style={{ paddingLeft: '8px', borderLeft: '1px solid var(--border)' }}>
+                            <span className="text-[10px] font-mono uppercase hidden sm:inline"
+                                style={{ color: 'var(--text-secondary)' }}>Data</span>
+                            <label className="relative inline-flex items-center cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={dataSource === 'demo'}
+                                    onChange={() => setDataSource(dataSource === 'demo' ? 'live' : 'demo')}
+                                    className="sr-only peer"
+                                />
+                                <div className="w-10 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-accent rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-accent"
+                                    style={{ backgroundColor: dataSource === 'demo' ? 'var(--accent)' : 'var(--border)' }}>
+                                </div>
+                                <span className="ml-2 text-[11px] font-mono"
+                                    style={{ color: 'var(--text-bright)' }}>
+                                    {dataSource === 'demo' ? 'DEMO' : 'LIVE'}
+                                </span>
+                            </label>
+                        </div>
                         <button className="btn-ghost" onClick={handleRefresh}>
                             Refresh
                         </button>
-                        <button className="btn-primary" onClick={handlePull} disabled={pulling}>
+                        <button className="btn-primary" onClick={handlePull} disabled={pulling || dataSource === 'demo'} title={dataSource === 'demo' ? 'Database updates are disabled in demo mode' : undefined}>
                             {pulling ? 'Pulling…' : '↓ Pull Update'}
                         </button>
                     </div>
@@ -128,9 +181,11 @@ export default function Layout({ children, lastPull, onRefresh, onMatchesUpdated
             )}
 
             {/* ── Page content — Fills available width ──────────────────────────── */}
-            <main className="flex-1 w-full px-4 lg:px-8 2xl:px-12 py-6 max-w-[2400px] mx-auto transition-all duration-300">
-                {children({ dateFrom, dateTo })}
-            </main>
+            <DataSourceContext.Provider value={{ dataSource, setDataSource }}>
+                <main className="flex-1 w-full px-4 lg:px-8 2xl:px-12 py-6 max-w-[2400px] mx-auto transition-all duration-300">
+                    {children({ dateFrom, dateTo, dataSource })}
+                </main>
+            </DataSourceContext.Provider>
         </div>
     );
 }

--- a/bet_dashboard/frontend/src/components/ServiceCard.tsx
+++ b/bet_dashboard/frontend/src/components/ServiceCard.tsx
@@ -6,6 +6,7 @@ import { LiveDot, TooltipIcon } from './ui';
 interface Props {
   info: ServiceInfo;
   onToggle: () => void;
+  disabled?: boolean;
 }
 
 const ICONS: Record<string, string> = {
@@ -14,7 +15,7 @@ const ICONS: Record<string, string> = {
   verifier: '⟳',
 };
 
-export default function ServiceCard({ info, onToggle }: Props) {
+export default function ServiceCard({ info, onToggle, disabled = false }: Props) {
   const active = info.alive && info.enabled;
 
   // Card header with icon, name, description and status
@@ -75,6 +76,8 @@ export default function ServiceCard({ info, onToggle }: Props) {
         className={active ? 'btn-danger' : 'btn-success'}
         style={{ justifyContent: 'center', width: '100%' }}
         onClick={onToggle}
+        disabled={disabled}
+        title={disabled ? 'Service controls are disabled in demo mode' : undefined}
       >
         {active ? 'Stop Service' : 'Start Service'}
       </button>

--- a/bet_dashboard/frontend/src/pages/Analytics.tsx
+++ b/bet_dashboard/frontend/src/pages/Analytics.tsx
@@ -7,7 +7,7 @@ import { fetchAnalytics } from '../api/data';
 import { SectionHeader, TooltipIcon } from '../components/ui';
 import { ProfileSelector } from '../components/ui/ProfileSelector';
 import type { GlobalFilters } from '../components/Layout';
-import type { AnalyticsData, MarketBreakdown, LeagueBreakdown, SlipStats } from '../types';
+import type { AnalyticsData, MarketBreakdown, LeagueBreakdown, SlipStats, AttributionResult, AttributionDimension, AttributionDriver } from '../types';
 import { useProfileSelection } from '../hooks/useProfileSelection';
 
 // ── Shared tooltip style ───────────────────────────────────────────────────────
@@ -135,6 +135,306 @@ function FinancialTile({ label, value, sub, color, tip, badge }: {
             </div>
             {sub && <span className="text-[10px] font-mono" style={{ color: 'var(--text-secondary)' }}>{sub}</span>}
         </div>
+    );
+}
+
+// ── Profit Attribution Waterfall ─────────────────────────────────────────────
+
+interface ProfitAttributionCardProps {
+    data: AttributionResult | null | undefined;
+}
+
+export function ProfitAttributionExplorer({ data }: ProfitAttributionCardProps) {
+    const dimensions: AttributionDimension[] = data?.dimensions || [];
+    const drivers: AttributionDriver[] = data?.drivers || [];
+    if (!data || !dimensions.length) {
+        return <ProfitAttributionCard data={data} />;
+    }
+    const money = (value: number) => `${value >= 0 ? '+' : ''}${value.toFixed(2)}U`;
+    return (
+        <ChartCard title="Profit Attribution" tip="Actual settled profit, grouped independently by decision factor. The factor totals are alternate views of the same slips and should not be added together.">
+            <div className="mb-4 rounded-lg border border-[var(--border)] bg-[var(--bg-base)]/40 px-4 py-3">
+                <div className="flex flex-wrap items-end justify-between gap-3">
+                    <div>
+                        <p className="text-[10px] font-mono uppercase tracking-widest" style={{ color: 'var(--text-secondary)' }}>Net profit from settled slips</p>
+                        <p className="mt-1 text-2xl font-mono font-bold" style={{ color: data.total_profit >= 0 ? 'var(--win)' : 'var(--loss)' }}>{money(data.total_profit)}</p>
+                    </div>
+                    <p className="max-w-[560px] text-[11px] leading-5" style={{ color: 'var(--text-secondary)' }}>
+                        This answers two different questions: which individual slips moved the bankroll, and which construction choices performed best. Market and league performance remain in their dedicated intelligence panels below.
+                    </p>
+                </div>
+                <div className="mt-3 flex gap-4 text-[10px] font-mono" style={{ color: 'var(--text-secondary)' }}>
+                    <span>{data.settled_slips ?? 0} settled slips</span><span>{data.settled_legs ?? 0} settled legs</span>
+                </div>
+            </div>
+            {drivers.length > 0 && (
+                <div className="mb-4 grid gap-3 lg:grid-cols-2">
+                    {(['Top Profit Drivers', 'Biggest Profit Drags'] as const).map((title, sectionIndex) => {
+                        const rows = sectionIndex === 0 ? drivers.slice(0, 5) : [...drivers].sort((a, b) => a.profit - b.profit).slice(0, 5);
+                        return (
+                            <div key={title} className="overflow-hidden rounded-lg border border-[var(--border)]">
+                                <div className="border-b border-[var(--border)] bg-[var(--bg-base)]/50 px-3 py-2">
+                                    <p className="font-display text-xs font-bold" style={{ color: 'var(--text-bright)' }}>{title}</p>
+                                    <p className="mt-0.5 text-[10px]" style={{ color: 'var(--text-secondary)' }}>Settled slips that moved the bankroll most</p>
+                                </div>
+                                <div className="divide-y divide-[var(--border)]">
+                                    {rows.map((slip) => (
+                                        <div key={`${title}-${slip.slip_id}`} className="px-3 py-2.5">
+                                            <div className="flex items-center justify-between gap-3">
+                                                <p className="text-[11px] font-mono" style={{ color: 'var(--text-bright)' }}>Slip #{slip.slip_id} · {slip.date} · {slip.profile}</p>
+                                                <p className="text-[11px] font-mono font-bold" style={{ color: slip.profit >= 0 ? 'var(--win)' : 'var(--loss)' }}>{money(slip.profit)}</p>
+                                            </div>
+                                            <p className="mt-1 truncate text-[10px]" style={{ color: 'var(--text-secondary)' }}>{slip.legs} legs · {slip.total_odds.toFixed(2)} total odds · {slip.stake.toFixed(2)}U stake · {slip.selections.join(' + ')}</p>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+            <div className="grid gap-3 md:grid-cols-2">
+                {dimensions.map((dimension) => (
+                    <div key={dimension.name} className="overflow-hidden rounded-lg border border-[var(--border)]">
+                        <div className="border-b border-[var(--border)] bg-[var(--bg-base)]/50 px-3 py-2">
+                            <p className="font-display text-xs font-bold" style={{ color: 'var(--text-bright)' }}>{dimension.name}</p>
+                            <p className="mt-0.5 text-[10px]" style={{ color: 'var(--text-secondary)' }}>Profit contribution by group</p>
+                        </div>
+                        <div className="divide-y divide-[var(--border)]">
+                            {[...dimension.groups].sort((a, b) => Math.abs(b.profit) - Math.abs(a.profit)).map((group) => (
+                                <div key={group.name} className="grid grid-cols-[minmax(0,1fr)_auto] gap-2 px-3 py-2.5">
+                                    <div className="min-w-0">
+                                        <p className="truncate text-[11px]" style={{ color: 'var(--text-bright)' }}>{group.name}</p>
+                                        <p className="mt-1 text-[10px] font-mono" style={{ color: 'var(--text-secondary)' }}>
+                                            {group.bets} bets · {group.wins}W / {group.losses}L · {group.stake.toFixed(2)}U staked
+                                        </p>
+                                    </div>
+                                    <div className="text-right font-mono">
+                                        <p className="text-[11px] font-bold" style={{ color: group.profit >= 0 ? 'var(--win)' : 'var(--loss)' }}>{money(group.profit)}</p>
+                                        <p className="mt-1 text-[10px]" style={{ color: group.roi_percentage >= 0 ? 'var(--win)' : 'var(--loss)' }}>{group.roi_percentage >= 0 ? '+' : ''}{group.roi_percentage.toFixed(1)}% ROI</p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </ChartCard>
+    );
+}
+
+function ProfitAttributionCard({ data }: ProfitAttributionCardProps) {
+    if (!data?.components?.length) {
+        return (
+            <ChartCard title="Profit Attribution" tip="Decomposes net profit into decision dimensions using sequential Shapley approximation. Green = positive driver, Red = negative driver.">
+                <div className="flex items-center justify-center h-60">
+                    <p className="font-mono text-xs" style={{ color: 'var(--text-secondary)' }}>
+                        No attribution data available.
+                    </p>
+                </div>
+            </ChartCard>
+        );
+    }
+
+    const components = data.components;
+    const totalProfit = data.total_profit;
+
+    type WaterfallPoint = {
+        name: string;
+        value: number;
+        percentage: number;
+        start: number;
+        end: number;
+        isTotal: boolean;
+        isPositive: boolean;
+        subComponents: NonNullable<AttributionResult['components'][number]['sub_components']>;
+    };
+
+    let cumulative = 0;
+    const waterfallData: WaterfallPoint[] = components.map((comp) => {
+        const start = cumulative;
+        const end = cumulative + comp.value;
+        cumulative = end;
+        return {
+            name: comp.name,
+            value: comp.value,
+            percentage: comp.percentage,
+            start,
+            end,
+            isTotal: comp.name === "Residual (Noise)",
+            isPositive: comp.value >= 0,
+            subComponents: comp.sub_components || [],
+        };
+    });
+
+    waterfallData.push({
+        name: "Total Profit",
+        value: totalProfit,
+        percentage: 100,
+        start: 0,
+        end: totalProfit,
+        isTotal: true,
+        isPositive: totalProfit >= 0,
+        subComponents: [],
+    });
+
+    const minCumulative = Math.min(0, ...waterfallData.map(d => Math.min(d.start, d.end)));
+    const maxCumulative = Math.max(0, ...waterfallData.map(d => Math.max(d.start, d.end)));
+    const domain = Math.max(maxCumulative - minCumulative, 0.5);
+
+    const axisTicks = useMemo(() => {
+        const ticks = 5;
+        return Array.from({ length: ticks }, (_, i) => {
+            const value = minCumulative + (domain * i) / (ticks - 1);
+            return {
+                value,
+                pct: ((value - minCumulative) / domain) * 100,
+            };
+        });
+    }, [domain, minCumulative]);
+
+    const scale = (value: number) => ((value - minCumulative) / domain) * 100;
+
+    const rowHeight = 34;
+    const chartHeight = waterfallData.length * rowHeight + 56;
+    const zeroPct = scale(0);
+
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const hovered = hoveredIndex !== null ? waterfallData[hoveredIndex] : null;
+
+    return (
+        <ChartCard title="Profit Attribution" tip="Decomposes net profit into decision dimensions using sequential Shapley approximation. Green = positive driver, Red = negative driver. Click a bar for sub-breakdown.">
+            <div className="relative rounded-xl border border-[var(--border)] bg-[var(--bg-base)]/40 overflow-hidden" style={{ minHeight: chartHeight }}>
+                <div className="absolute inset-x-0 top-0 px-4 pt-3 pb-1 text-[9px] font-mono text-[var(--text-secondary)]">
+                    <div className="relative" style={{ height: 14 }}>
+                        {axisTicks.map(tick => (
+                            <div
+                                key={`${tick.value.toFixed(2)}`}
+                                className="absolute -translate-x-1/2"
+                                style={{ left: `${tick.pct}%` }}
+                            >
+                                <span>{`${tick.value >= 0 ? '+' : ''}${tick.value.toFixed(2)}U`}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                <div className="absolute inset-0 px-4 pt-8 pb-12">
+                    <div className="relative h-full">
+                        <div
+                            className="absolute top-0 bottom-0 w-px"
+                            style={{
+                                left: `${zeroPct}%`,
+                                background: 'rgba(125, 160, 220, 0.22)',
+                            }}
+                        />
+
+                        {waterfallData.map((entry, index) => {
+                            const startPct = scale(Math.min(entry.start, entry.end));
+                            const endPct = scale(Math.max(entry.start, entry.end));
+                            const barWidthPct = Math.max(endPct - startPct, 0.8);
+                            const barColor = entry.isTotal
+                                ? 'var(--accent)'
+                                : entry.isPositive
+                                    ? 'var(--win)'
+                                    : 'var(--loss)';
+
+                            return (
+                                <div
+                                    key={entry.name}
+                                    className="absolute left-0 right-0"
+                                    style={{ top: `${index * rowHeight + 4}px`, height: `${rowHeight - 4}px` }}
+                                >
+                                    <div
+                                        className="absolute left-0 top-0 w-[145px] pr-3 text-right text-[11px] leading-5"
+                                        style={{ color: 'var(--text-bright)' }}
+                                    >
+                                        {entry.name}
+                                    </div>
+
+                                    <div className="absolute left-[145px] right-0 top-0 h-full">
+                                        <div
+                                            className="absolute top-1/2 h-4 -translate-y-1/2 rounded-sm"
+                                            style={{
+                                                left: `calc(${startPct}% )`,
+                                                width: `max(${barWidthPct}%, 4px)`,
+                                                background: barColor,
+                                                opacity: entry.isTotal ? 1 : 0.9,
+                                                boxShadow: `0 0 0 1px color-mix(in srgb, ${barColor} 35%, transparent)`,
+                                            }}
+                                            title={[
+                                                entry.name,
+                                                `Contribution: ${entry.value >= 0 ? '+' : ''}${entry.value.toFixed(2)}U`,
+                                                `% of Total: ${entry.percentage.toFixed(1)}%`,
+                                            ].join('\n')}
+                                            onMouseEnter={() => setHoveredIndex(index)}
+                                            onMouseLeave={() => setHoveredIndex(null)}
+                                        />
+
+                                        {index > 0 && (
+                                            <div
+                                                className="absolute top-1/2 h-px"
+                                                style={{
+                                                    left: `${scale(waterfallData[index - 1].end)}%`,
+                                                    width: `${Math.max(Math.abs(scale(waterfallData[index - 1].end) - scale(entry.start)), 0)}%`,
+                                                    background: 'rgba(125, 160, 220, 0.28)',
+                                                    transform: 'translateY(-0.5px)',
+                                                }}
+                                            />
+                                        )}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {hovered && (
+                    <div className="absolute top-4 right-4 z-10 rounded-lg border border-[var(--border-strong)] bg-[var(--bg-card)] px-4 py-3 shadow-lg max-w-[280px]">
+                        <p className="font-display font-bold text-sm" style={{ color: 'var(--text-bright)' }}>
+                            {hovered.name}
+                        </p>
+                        <p className="mt-1 text-[11px] font-mono" style={{ color: hovered.value >= 0 ? 'var(--win)' : 'var(--loss)' }}>
+                            Contribution: {hovered.value >= 0 ? '+' : ''}{hovered.value.toFixed(2)}U
+                        </p>
+                        <p className="text-[11px] font-mono" style={{ color: 'var(--text-secondary)' }}>
+                            % of Total: {hovered.percentage.toFixed(1)}%
+                        </p>
+                        {hovered.subComponents.length > 0 && (
+                            <div className="mt-3 pt-3 border-t border-[var(--border)]">
+                                <p className="font-mono text-[10px] uppercase tracking-widest mb-1" style={{ color: 'var(--text-secondary)' }}>
+                                    Sub-breakdown
+                                </p>
+                                <div className="space-y-1 max-h-32 overflow-y-auto pr-1">
+                                    {hovered.subComponents.slice(0, 5).map((sub, i) => (
+                                        <p key={i} className="font-mono text-[10px]" style={{ color: 'var(--text-secondary)' }}>
+                                            {sub.name}: <span style={{ color: sub.value >= 0 ? 'var(--win)' : 'var(--loss)' }}>
+                                                {sub.value >= 0 ? '+' : ''}{sub.value.toFixed(2)}U
+                                            </span>{sub.count ? ` (n=${sub.count})` : ''}
+                                        </p>
+                                    ))}
+                                    {hovered.subComponents.length > 5 && (
+                                        <p className="font-mono text-[10px]" style={{ color: 'var(--text-secondary)' }}>
+                                            ...and {hovered.subComponents.length - 5} more
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+            <div className="flex gap-4 mt-3 pt-3" style={{ borderTop: '1px solid var(--border)' }}>
+                <span className="text-[11px] font-mono" style={{ color: 'var(--text-secondary)' }}>
+                    Total: <span style={{ color: totalProfit >= 0 ? 'var(--win)' : 'var(--loss)', fontWeight: 'bold' }}>
+                        {totalProfit >= 0 ? '+' : ''}{totalProfit.toFixed(2)}U
+                    </span>
+                </span>
+                <span className="text-[11px] font-mono" style={{ color: 'var(--text-secondary)' }}>
+                    Components: {components.length}
+                </span>
+            </div>
+        </ChartCard>
     );
 }
 
@@ -821,6 +1121,7 @@ export default function Analytics({ filters, refreshKey }: Props) {
             const params: Record<string, unknown> = {
                 date_from: filters.dateFrom || undefined,
                 date_to: filters.dateTo || undefined,
+                data_source: filters.dataSource,
             };
             if (selectedProfiles.length > 0) params.profiles = selectedProfiles;
             const d = await fetchAnalytics(params as any);
@@ -852,7 +1153,7 @@ export default function Analytics({ filters, refreshKey }: Props) {
                 drawdown: [], return_distribution: null, time_patterns: null,
             });
         } finally { setLoading(false); }
-    }, [selectedProfiles, filters, refreshKey]);
+    }, [selectedProfiles, filters.dateFrom, filters.dateTo, filters.dataSource, refreshKey]);
 
     useEffect(() => { load(); }, [load]);
 
@@ -1353,6 +1654,8 @@ export default function Analytics({ filters, refreshKey }: Props) {
                     </p>
                 )}
             </div>
+
+            {/* ── Profit Attribution Waterfall ───────────────────────────────── */}
         </div>
     );
 }

--- a/bet_dashboard/frontend/src/pages/BettingTips.tsx
+++ b/bet_dashboard/frontend/src/pages/BettingTips.tsx
@@ -43,7 +43,7 @@ export default function BettingTips({ filters, refreshKey }: Props) {
         let cancelled = false;
         const loadSlips = async () => {
             try {
-                const slipsData = await fetchSlips({ hide_settled: true });
+                const slipsData = await fetchSlips({ hide_settled: true, data_source: filters.dataSource });
                 const selections = new Set<string>();
                 slipsData.slips.forEach((slip: any) => {
                     // Only consider pending or live slips
@@ -64,7 +64,7 @@ export default function BettingTips({ filters, refreshKey }: Props) {
         };
         loadSlips();
         return () => { cancelled = true; };
-    }, [refreshKey]); // Refetch when refreshKey changes
+    }, [filters.dataSource, refreshKey]); // Refetch when refreshKey or data source changes
 
     // Local filter state with localStorage persistence
     const [search, setSearch] = useState(() => {
@@ -138,16 +138,16 @@ export default function BettingTips({ filters, refreshKey }: Props) {
     }, [search, minConsensus, minOdds, onlySignificantMovement, page, sortBy, sortDir, pendingLegs]);
 
     // Reset to page 1 when any filter changes
-    useEffect(() => { setPage(1); }, [filters.dateFrom, filters.dateTo, refreshKey, search, minConsensus, minOdds, onlySignificantMovement]);
+    useEffect(() => { setPage(1); }, [filters.dateFrom, filters.dateTo, filters.dataSource, refreshKey, search, minConsensus, minOdds, onlySignificantMovement]);
 
     // Fetch odds movements
     useEffect(() => {
         let cancelled = false;
-        getAllMovements()
+        getAllMovements(filters.dataSource)
             .then(d => { if (!cancelled) setMovements(d); })
             .catch(() => {});
         return () => { cancelled = true; };
-    }, [refreshKey]);
+    }, [filters.dataSource, refreshKey]);
 
     useEffect(() => {
         let cancelled = false;
@@ -162,6 +162,7 @@ export default function BettingTips({ filters, refreshKey }: Props) {
             min_consensus: minConsensus,
             min_odds: minOdds,
             only_significant_movement: onlySignificantMovement || undefined,
+            data_source: filters.dataSource,
         })
             .then(d => { if (!cancelled) { setData(d); setLoading(false); } })
             .catch(() => {
@@ -171,7 +172,7 @@ export default function BettingTips({ filters, refreshKey }: Props) {
                 }
             });
         return () => { cancelled = true; };
-    }, [page, filters.dateFrom, filters.dateTo, search, minConsensus, minOdds, onlySignificantMovement, sortBy, sortDir, refreshKey]);
+    }, [page, filters.dateFrom, filters.dateTo, filters.dataSource, search, minConsensus, minOdds, onlySignificantMovement, sortBy, sortDir, refreshKey]);
 
     function handleSort(key: string) {
         if (key === sortBy) setSortDir(d => d === 'asc' ? 'desc' : 'asc');
@@ -253,7 +254,7 @@ export default function BettingTips({ filters, refreshKey }: Props) {
             setPendingLegs([]);
             // Refresh slip selections after adding
             try {
-                const slipsData = await fetchSlips({ hide_settled: true });
+                const slipsData = await fetchSlips({ hide_settled: true, data_source: filters.dataSource });
                 const selections = new Set<string>();
                 slipsData.slips.forEach((slip: any) => {
                     if (slip.slip_status === 'Pending' || slip.slip_status === 'Live') {

--- a/bet_dashboard/frontend/src/pages/OddsAlert.tsx
+++ b/bet_dashboard/frontend/src/pages/OddsAlert.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { getSignificantMovements } from '../api/oddsHistory';
 import { fetchMatches } from '../api/matches';
 import { OddsMovementIndicator } from '../components/OddsMovementIndicator';
+import { useDataSource } from '../components/Layout';
 import type { MarketMovementDetail, Match } from '../types';
 import { MARKET_COLUMNS } from '../config/marketConfig';
 
@@ -63,6 +64,7 @@ const CATEGORY_META: Record<string, { title: string; color: string; desc: string
 };
 
 export default function OddsAlert() {
+    const { dataSource } = useDataSource();
     const [matches, setMatches] = useState<MovementMatch[]>([]);
     const [loading, setLoading] = useState(true);
 
@@ -71,8 +73,8 @@ export default function OddsAlert() {
         (async () => {
             try {
                 const [movements, firstPage] = await Promise.all([
-                    getSignificantMovements(),
-                    fetchMatches({ page: 1, page_size: PAGE_SIZE }),
+                    getSignificantMovements(dataSource),
+                    fetchMatches({ page: 1, page_size: PAGE_SIZE, data_source: dataSource }),
                 ]);
                 if (cancelled) return;
                 const allMatches: Match[] = [...firstPage.matches];
@@ -80,7 +82,7 @@ export default function OddsAlert() {
                 if (totalPages > 1) {
                     const remaining = await Promise.all(
                         Array.from({ length: totalPages - 1 }, (_, i) =>
-                            fetchMatches({ page: i + 2, page_size: PAGE_SIZE })
+                            fetchMatches({ page: i + 2, page_size: PAGE_SIZE, data_source: dataSource })
                         )
                     );
                     for (const pg of remaining) allMatches.push(...pg.matches);
@@ -106,7 +108,7 @@ export default function OddsAlert() {
             }
         })();
         return () => { cancelled = true; };
-    }, []);
+    }, [dataSource]);
 
     const cats = categorizeMatches(matches);
 

--- a/bet_dashboard/frontend/src/pages/Services.tsx
+++ b/bet_dashboard/frontend/src/pages/Services.tsx
@@ -9,6 +9,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import dayjs from 'dayjs';
+import { useDataSource } from '../components/Layout';
 
 // Custom theme mapping the high-fidelity CSS variable tokens
 const muiDarkTheme = createTheme({
@@ -95,6 +96,7 @@ const muiDarkTheme = createTheme({
 });
 
 export default function Services() {
+    const { dataSource } = useDataSource();
     const [data, setData] = useState<ServicesData | null>(null);
     const [genHour, setGenHour] = useState(8);
     const [genMinute, setGenMinute] = useState(0);
@@ -111,6 +113,7 @@ export default function Services() {
     useEffect(() => { load(); }, [load]);
 
     async function handleSave() {
+        if (dataSource === 'demo') { setStatus('Demo mode is read-only.'); return; }
         await saveServiceSettings(genHour, genMinute);
         setStatus('✓ Settings saved — schedules recalculated');
         load();
@@ -157,6 +160,7 @@ export default function Services() {
                         key={svc.name}
                         info={svc}
                         onToggle={() => handleToggle(svc.name)}
+                        disabled={dataSource === 'demo'}
                     />
                 ))}
 
@@ -189,6 +193,7 @@ export default function Services() {
                                                     setGenMinute(newValue.minute());
                                                 }
                                             }}
+                                            disabled={dataSource === 'demo'}
                                             slotProps={{
                                                 actionBar: {
                                                     actions: []
@@ -202,7 +207,7 @@ export default function Services() {
                     </div>
 
                     <div className="flex items-center gap-3 pt-4 border-t" style={{ borderColor: 'var(--border)' }}>
-                        <button className="btn-primary" onClick={handleSave}>Save Settings</button>
+                        <button className="btn-primary" onClick={handleSave} disabled={dataSource === 'demo'}>Save Settings</button>
                         {status && (
                             <span className="text-[11px] font-mono" style={{ color: 'var(--win)' }}>{status}</span>
                         )}

--- a/bet_dashboard/frontend/src/pages/Slips.tsx
+++ b/bet_dashboard/frontend/src/pages/Slips.tsx
@@ -68,6 +68,7 @@ export default function Slips({ filters, refreshKey, liveData: externalLiveData 
                 date_to: filters.dateTo || undefined,
                 hide_settled: hideSettled,
                 live_only: liveOnly,
+                data_source: filters.dataSource,
             };
             if (selectedProfiles.length > 0) {
                 params.profiles = selectedProfiles;
@@ -90,7 +91,7 @@ export default function Slips({ filters, refreshKey, liveData: externalLiveData 
             // Set empty state on error
             setData({ slips: [], stats: { total_settled: 0, total_won_count: 0, win_rate: 0, implied_win_rate: 0, edge: 0, total_units_bet: 0, gross_return: 0, net_profit: 0, roi_percentage: 0, avg_odds: 0, avg_units: 0, units_std: 0, pending_count: 0, sharpe_ratio: null , kelly_suggested_units: 0, edge_trend: "neutral", recent_edge_value: 0.0, biggest_win_units: null, biggest_loss_units: null, best_day_pnl: null, worst_day_pnl: null, current_streak: 0, longest_win_streak: 0, longest_loss_streak: 0, profit_factor: 0 }, profiles: [] });
         } finally { setLoading(false); }
-    }, [selectedProfiles, filters, hideSettled, liveOnly, refreshKey]);
+    }, [selectedProfiles, filters.dateFrom, filters.dateTo, filters.dataSource, hideSettled, liveOnly, refreshKey]);
 
     useEffect(() => { load(); }, [load]);
 

--- a/bet_dashboard/frontend/src/pages/SmartBuilder.tsx
+++ b/bet_dashboard/frontend/src/pages/SmartBuilder.tsx
@@ -83,37 +83,37 @@ export default function SmartBuilder({ filters, refreshKey }: Props) {
 
     // Load profiles + excluded on mount
     useEffect(() => {
-        fetchProfiles().then(p => setProfiles(p ?? {})).catch(() => setProfiles({}));
-        fetchExcludedDetails().then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
-        fetchLeagues().then(setAvailableLeagues).catch(() => setAvailableLeagues([]));
-    }, []);
+        fetchProfiles(filters.dataSource).then(p => setProfiles(p ?? {})).catch(() => setProfiles({}));
+        fetchExcludedDetails(filters.dataSource).then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
+        fetchLeagues(filters.dataSource).then(setAvailableLeagues).catch(() => setAvailableLeagues([]));
+    }, [filters.dataSource]);
 
     // Compute merged config with global date filters (for preview only)
     const mergedCfg = { ...cfg, date_from: filters.dateFrom || null, date_to: filters.dateTo || null };
 
     // Debounced preview — 350ms after any config change
-    const triggerPreview = useCallback((config: BuilderConfig) => {
+    const triggerPreview = useCallback((config: BuilderConfig, dataSource: 'live' | 'demo' = filters.dataSource) => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
         debounceRef.current = setTimeout(async () => {
             setLoading(true);
             try {
-                const result = await fetchPreview(config);
+                const result = await fetchPreview(config, dataSource);
                 setPreview(result);
             } catch {
                 setPreview({ legs: [], total_odds: 1, pending_urls: [] });
             }
             finally { setLoading(false); }
         }, 350);
-    }, []);
+    }, [filters.dataSource]);
 
     function handleCfgChange(next: BuilderConfig) {
         setCfg(next);
         setActiveName('manual');
-        triggerPreview({ ...next, date_from: filters.dateFrom || null, date_to: filters.dateTo || null });
+        triggerPreview({ ...next, date_from: filters.dateFrom || null, date_to: filters.dateTo || null }, filters.dataSource);
     }
 
     // Trigger preview when refreshKey or global filters change
-    useEffect(() => { triggerPreview(mergedCfg); }, [refreshKey, filters.dateFrom, filters.dateTo]); // eslint-disable-line
+    useEffect(() => { triggerPreview(mergedCfg, filters.dataSource); }, [refreshKey, filters.dateFrom, filters.dateTo, filters.dataSource]); // eslint-disable-line
 
     // Auto-calculate units if target payout is set — anchored to LIVE PREVIEW odds
     useEffect(() => {
@@ -136,15 +136,17 @@ export default function SmartBuilder({ filters, refreshKey }: Props) {
     }, [targetPayout, preview?.total_odds, preview?.legs.length, cfg.target_odds, units]);
 
     async function handleExclude(url: string) {
+        if (filters.dataSource === 'demo') { setStatus('Demo mode is read-only.'); return; }
         await addExcluded(url);
-        fetchExcludedDetails().then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
-        triggerPreview(mergedCfg);
+        fetchExcludedDetails(filters.dataSource).then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
+        triggerPreview(mergedCfg, filters.dataSource);
     }
 
     async function handleClearExcluded() {
+        if (filters.dataSource === 'demo') { setStatus('Demo mode is read-only.'); return; }
         await clearExcluded();
         setExcludedDetails([]);
-        triggerPreview(mergedCfg);
+        triggerPreview(mergedCfg, filters.dataSource);
     }
 
     function loadProfile(name: string, data: any) {
@@ -178,31 +180,34 @@ export default function SmartBuilder({ filters, refreshKey }: Props) {
         setUnits(data.units ?? 1);
         setRunDaily(data.run_daily_count ?? 0);
         setTargetPayout(data.target_payout ?? 0);
-        triggerPreview({ ...next, date_from: filters.dateFrom || null, date_to: filters.dateTo || null });
+        triggerPreview({ ...next, date_from: filters.dateFrom || null, date_to: filters.dateTo || null }, filters.dataSource);
     }
 
     async function handleSaveProfile() {
+        if (filters.dataSource === 'demo') { setStatus('Demo mode is read-only.'); return; }
         const clean = activeName.replace(/[^a-z0-9_-]/gi, '').toLowerCase();
         if (!clean || clean === 'manual') {
             setStatus('Enter a profile name first.'); return;
         }
         const { date_from, date_to, ...cfgWithoutDates } = cfg;
         await saveProfile({ name: clean, ...cfgWithoutDates, units, target_payout: targetPayout, run_daily_count: runDaily });
-        const updated = await fetchProfiles();
+        const updated = await fetchProfiles(filters.dataSource);
         setProfiles(updated ?? {});
         setStatus(`✓ Profile '${clean}' saved`);
     }
 
     async function handleDeleteProfile() {
+        if (filters.dataSource === 'demo') { setStatus('Demo mode is read-only.'); return; }
         if (!activeName || activeName === 'manual') return;
         await deleteProfile(activeName);
-        const updated = await fetchProfiles();
+        const updated = await fetchProfiles(filters.dataSource);
         setProfiles(updated ?? {});
         setActiveName('manual');
         setStatus(`Deleted '${activeName}'`);
     }
 
     async function handleAddToSlips() {
+        if (filters.dataSource === 'demo') { setStatus('Demo mode is read-only.'); return; }
         if (!preview?.legs.length) {
             setStatus('No legs in preview.'); return;
         }
@@ -237,8 +242,8 @@ export default function SmartBuilder({ filters, refreshKey }: Props) {
 
         const id = await addSlip(activeName, manualLegs, units);
         setStatus(`✓ Slip #${id} added to '${activeName}'`);
-        triggerPreview(mergedCfg);
-        fetchExcludedDetails().then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
+        triggerPreview(mergedCfg, filters.dataSource);
+        fetchExcludedDetails(filters.dataSource).then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
     }
 
     return (
@@ -441,10 +446,10 @@ export default function SmartBuilder({ filters, refreshKey }: Props) {
                                             </div>
                                             <button className="btn-icon shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
                                                 onClick={() => {
-                                                    if (item.reason === "Manually excluded") {
+                                                    if (item.reason === "Manually excluded" && filters.dataSource !== 'demo') {
                                                         removeExcluded(item.url).then(() => {
-                                                            fetchExcludedDetails().then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
-                                                            triggerPreview(mergedCfg);
+                                                            fetchExcludedDetails(filters.dataSource).then(d => setExcludedDetails(d ?? [])).catch(() => setExcludedDetails([]));
+                                                            triggerPreview(mergedCfg, filters.dataSource);
                                                         });
                                                     }
                                                 }}

--- a/bet_dashboard/frontend/src/types/index.ts
+++ b/bet_dashboard/frontend/src/types/index.ts
@@ -1,3 +1,7 @@
+// ── Data Source ──────────────────────────────────────────────────────────────
+
+export type DataSource = 'live' | 'demo';
+
 // ── Match ─────────────────────────────────────────────────────────────────────
 
 export interface Match {
@@ -228,6 +232,41 @@ export interface LeagueBreakdown {
     avg_odds: number; net_profit: number;
 }
 
+export interface AttributionComponent {
+    name: string;
+    value: number;
+    percentage: number;
+    sub_components?: {
+        name: string;
+        value: number;
+        count?: number;
+    }[];
+}
+
+export interface AttributionResult {
+    total_profit: number;
+    components: AttributionComponent[];
+    settled_slips?: number;
+    settled_legs?: number;
+    dimensions?: AttributionDimension[];
+    drivers?: AttributionDriver[];
+}
+
+export interface AttributionDriver {
+    slip_id: number; date: string; status: string; profile: string;
+    stake: number; total_odds: number; legs: number; profit: number;
+    selections: string[];
+}
+
+export interface AttributionDimension {
+    name: string; groups: AttributionGroup[];
+}
+
+export interface AttributionGroup {
+    name: string; profit: number; stake: number; bets: number;
+    wins: number; losses: number; roi_percentage: number;
+}
+
 export interface RollingEdgePoint {
     date: string; rolling_edge: number; rolling_win_rate: number;
     rolling_implied: number; sample_size: number;
@@ -269,6 +308,7 @@ export interface AnalyticsData {
         markets: string[];
         matrix: Record<string, Record<string, { win_rate: number; edge: number; total: number }>>;
     };
+    profit_attribution?: AttributionResult;
 }
 
 // ── Services ──────────────────────────────────────────────────────────────────

--- a/tests/test_api_demo_data.py
+++ b/tests/test_api_demo_data.py
@@ -1,0 +1,617 @@
+"""
+Integration tests for API endpoints with demo data.
+
+Tests the data_source=demo|live parameter routing for all 5 endpoints:
+- /api/analytics
+- /api/slips
+- /api/matches
+- /api/profiles
+- /api/odds-history
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from bet_dashboard.backend.main import create_app
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app."""
+    app = create_app()
+    return TestClient(app)
+
+
+class TestAnalyticsEndpoint:
+    """Test /api/analytics endpoint with data_source parameter."""
+
+    def test_analytics_demo_data_source(self, client):
+        """Test analytics endpoint with data_source=demo."""
+        response = client.get("/api/analytics", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Verify all expected keys present
+        expected_keys = [
+            "history", "market_accuracy", "pnl_by_market", "odds_distribution",
+            "correlation", "profile_scatter", "stats", "profiles",
+            "market_breakdown", "league_breakdown", "rolling_edge",
+            "drawdown", "return_distribution", "time_patterns",
+            "correlation_matrix", "profit_attribution"
+        ]
+        for key in expected_keys:
+            assert key in data, f"Missing key: {key}"
+        
+        # Verify stats structure
+        stats = data["stats"]
+        assert stats["total_settled"] > 0
+        assert 0 <= stats["win_rate"] <= 100
+        assert stats["total_units_bet"] > 0
+        assert stats["avg_odds"] > 1.0
+        assert stats["profit_factor"] >= 0
+
+    def test_analytics_live_data_source(self, client):
+        """Test analytics endpoint with data_source=live (default)."""
+        response = client.get("/api/analytics", params={"data_source": "live"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should return live data structure (may be empty if no live data)
+        expected_keys = [
+            "history", "market_accuracy", "pnl_by_market", "odds_distribution",
+            "correlation", "profile_scatter", "stats", "profiles",
+            "market_breakdown", "league_breakdown", "rolling_edge",
+            "drawdown", "return_distribution", "time_patterns",
+            "correlation_matrix", "profit_attribution"
+        ]
+        for key in expected_keys:
+            assert key in data, f"Missing key: {key}"
+
+    def test_analytics_invalid_data_source(self, client):
+        """Test analytics endpoint with invalid data_source."""
+        response = client.get("/api/analytics", params={"data_source": "invalid"})
+        assert response.status_code == 422  # Validation error
+
+    def test_analytics_profile_filter_demo(self, client):
+        """Test analytics with profile filter and demo data."""
+        response = client.get("/api/analytics", params={
+            "data_source": "demo",
+            "profiles": ["Conservative"]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        # All profile scatter data should be Conservative
+        profiles_in_result = {s["profile"] for s in data["profile_scatter"]}
+        assert profiles_in_result == {"Conservative"}
+
+    def test_analytics_date_filter_demo(self, client):
+        """Test analytics with date filter and demo data."""
+        response = client.get("/api/analytics", params={
+            "data_source": "demo",
+            "date_from": "2026-03-01",
+            "date_to": "2026-03-31"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        # All history dates should be in March 2026
+        for day in data["history"]:
+            assert day["date"].startswith("2026-03")
+
+
+class TestSlipsEndpoint:
+    """Test /api/slips endpoint with data_source parameter."""
+
+    def test_slips_demo_data_source(self, client):
+        """Test slips endpoint with data_source=demo."""
+        response = client.get("/api/slips", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "slips" in data
+        assert "stats" in data
+        assert "profiles" in data
+        assert len(data["slips"]) > 0
+        assert set(data["profiles"]) == {"Conservative", "Balanced", "Aggressive"}
+
+    def test_slips_live_data_source(self, client):
+        """Test slips endpoint with data_source=live."""
+        response = client.get("/api/slips", params={"data_source": "live"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "slips" in data
+        assert "stats" in data
+        assert "profiles" in data
+
+    def test_slips_invalid_data_source(self, client):
+        """Test slips endpoint with invalid data_source."""
+        response = client.get("/api/slips", params={"data_source": "invalid"})
+        assert response.status_code == 422
+
+    def test_slips_profile_filter_demo(self, client):
+        """Test slips with profile filter and demo data."""
+        response = client.get("/api/slips", params={
+            "data_source": "demo",
+            "profiles": ["Conservative"]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for slip in data["slips"]:
+            assert slip["profile"] == "Conservative"
+        assert data["profiles"] == ["Conservative"]
+
+    def test_slips_hide_settled_demo(self, client):
+        """Test slips hide_settled filter with demo data."""
+        response = client.get("/api/slips", params={
+            "data_source": "demo",
+            "hide_settled": "true"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for slip in data["slips"]:
+            assert slip["slip_status"] not in ("Won", "Lost")
+            assert slip["slip_status"] in ("Pending", "Live")
+
+    def test_slips_live_only_demo(self, client):
+        """Test slips live_only filter with demo data."""
+        response = client.get("/api/slips", params={
+            "data_source": "demo",
+            "live_only": "true"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for slip in data["slips"]:
+            assert any(leg["status"] == "Live" for leg in slip["legs"])
+
+    def test_slips_date_filter_demo(self, client):
+        """Test slips with date filter and demo data."""
+        response = client.get("/api/slips", params={
+            "data_source": "demo",
+            "date_from": "2026-03-01",
+            "date_to": "2026-03-31"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for slip in data["slips"]:
+            assert "2026-03" <= slip["date_generated"] <= "2026-03-31"
+
+    def test_slip_structure_demo(self, client):
+        """Verify slip data structure with demo data."""
+        response = client.get("/api/slips", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        slip = data["slips"][0]
+        assert "slip_id" in slip
+        assert "date_generated" in slip
+        assert "profile" in slip
+        assert "total_odds" in slip
+        assert "units" in slip
+        assert "slip_status" in slip
+        assert "legs" in slip
+        assert "net_profit" in slip
+        
+        assert isinstance(slip["legs"], list)
+        assert len(slip["legs"]) > 0
+        
+        leg = slip["legs"][0]
+        assert "match_name" in leg
+        assert "datetime" in leg
+        assert "market" in leg
+        assert "market_type" in leg
+        assert "odds" in leg
+        assert "status" in leg
+        assert "result_url" in leg
+        assert "league" in leg
+
+    def test_net_profit_calculation_demo(self, client):
+        """Verify net_profit calculation for settled slips with demo data."""
+        response = client.get("/api/slips", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        for slip in data["slips"]:
+            if slip["slip_status"] == "Won":
+                expected_profit = round((slip["total_odds"] - 1) * slip["units"], 2)
+                assert abs(slip["net_profit"] - expected_profit) < 0.01
+            elif slip["slip_status"] == "Lost":
+                expected_profit = round(-slip["units"], 2)
+                assert abs(slip["net_profit"] - expected_profit) < 0.01
+            else:
+                assert slip["net_profit"] is None
+
+
+class TestMatchesEndpoint:
+    """Test /api/matches endpoint with data_source parameter."""
+
+    def test_matches_demo_data_source(self, client):
+        """Test matches endpoint with data_source=demo."""
+        response = client.get("/api/matches", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data
+        assert "total_pages" in data
+        assert "matches" in data
+        assert data["page"] == 1
+        assert data["page_size"] == 40
+        assert len(data["matches"]) <= 40
+        assert data["total"] > 0
+
+    def test_matches_live_data_source(self, client):
+        """Test matches endpoint with data_source=live."""
+        response = client.get("/api/matches", params={"data_source": "live"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data
+        assert "total_pages" in data
+        assert "matches" in data
+
+    def test_matches_invalid_data_source(self, client):
+        """Test matches endpoint with invalid data_source."""
+        response = client.get("/api/matches", params={"data_source": "invalid"})
+        assert response.status_code == 422
+
+    def test_matches_pagination_demo(self, client):
+        """Test matches pagination with demo data."""
+        page1 = client.get("/api/matches", params={"data_source": "demo", "page": 1, "page_size": 10})
+        page2 = client.get("/api/matches", params={"data_source": "demo", "page": 2, "page_size": 10})
+        
+        assert page1.status_code == 200
+        assert page2.status_code == 200
+        assert page1.json()["page"] == 1
+        assert page2.json()["page"] == 2
+        assert len(page1.json()["matches"]) == 10
+        assert len(page2.json()["matches"]) == 10
+        assert page1.json()["matches"][0]["match_id"] != page2.json()["matches"][0]["match_id"]
+        assert page1.json()["total"] == page2.json()["total"]
+        assert page1.json()["total_pages"] == page2.json()["total_pages"]
+
+    def test_matches_search_demo(self, client):
+        """Test matches search filter with demo data."""
+        response = client.get("/api/matches", params={
+            "data_source": "demo",
+            "search": "Arsenal"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for match in data["matches"]:
+            assert "arsenal" in match["home"].lower() or "arsenal" in match["away"].lower()
+
+    def test_matches_date_filter_demo(self, client):
+        """Test matches date range filter with demo data."""
+        response = client.get("/api/matches", params={
+            "data_source": "demo",
+            "date_from": "2026-03-01",
+            "date_to": "2026-03-31"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for match in data["matches"]:
+            if match["datetime"]:
+                assert "2026-03" <= match["datetime"][:10] <= "2026-03-31"
+
+    def test_matches_sort_demo(self, client):
+        """Test matches sorting with demo data."""
+        response = client.get("/api/matches", params={
+            "data_source": "demo",
+            "sort_by": "datetime",
+            "sort_dir": "asc"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        dates = [m["datetime"] for m in data["matches"] if m["datetime"]]
+        assert dates == sorted(dates)
+        
+        response_desc = client.get("/api/matches", params={
+            "data_source": "demo",
+            "sort_by": "datetime",
+            "sort_dir": "desc"
+        })
+        assert response_desc.status_code == 200
+        data_desc = response_desc.json()
+        dates_desc = [m["datetime"] for m in data_desc["matches"] if m["datetime"]]
+        assert dates_desc == sorted(dates_desc, reverse=True)
+
+    def test_matches_min_consensus_demo(self, client):
+        """Test matches min_consensus filter with demo data."""
+        response = client.get("/api/matches", params={
+            "data_source": "demo",
+            "min_consensus": 60
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for match in data["matches"]:
+            consensus_values = [
+                match.get("cons_home", 0),
+                match.get("cons_draw", 0),
+                match.get("cons_away", 0),
+                match.get("cons_over_25", 0),
+                match.get("cons_under_25", 0),
+                match.get("cons_btts_yes", 0),
+                match.get("cons_btts_no", 0),
+                match.get("cons_over_05", 0),
+                match.get("cons_under_05", 0),
+                match.get("cons_over_15", 0),
+                match.get("cons_under_15", 0),
+                match.get("cons_over_35", 0),
+                match.get("cons_under_35", 0),
+                match.get("cons_over_45", 0),
+                match.get("cons_under_45", 0),
+                match.get("cons_dc_1x", 0),
+                match.get("cons_dc_12", 0),
+                match.get("cons_dc_x2", 0),
+            ]
+            assert max(consensus_values) >= 60
+
+    def test_matches_min_odds_demo(self, client):
+        """Test matches min_odds filter with demo data."""
+        response = client.get("/api/matches", params={
+            "data_source": "demo",
+            "min_odds": 3.0
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        for match in data["matches"]:
+            odds_values = [
+                match.get("odds_home", 0),
+                match.get("odds_draw", 0),
+                match.get("odds_away", 0),
+                match.get("odds_over_25", 0),
+                match.get("odds_under_25", 0),
+                match.get("odds_btts_yes", 0),
+                match.get("odds_btts_no", 0),
+                match.get("odds_over_05", 0),
+                match.get("odds_under_05", 0),
+                match.get("odds_over_15", 0),
+                match.get("odds_under_15", 0),
+                match.get("odds_over_35", 0),
+                match.get("odds_under_35", 0),
+                match.get("odds_over_45", 0),
+                match.get("odds_under_45", 0),
+                match.get("odds_dc_1x", 0),
+                match.get("odds_dc_12", 0),
+                match.get("odds_dc_x2", 0),
+            ]
+            assert max(odds_values) >= 3.0
+
+    def test_match_structure_demo(self, client):
+        """Verify match data structure with demo data."""
+        response = client.get("/api/matches", params={"data_source": "demo", "page_size": 1})
+        assert response.status_code == 200
+        data = response.json()
+        match = data["matches"][0]
+        
+        required_fields = [
+            "match_id", "datetime", "home", "away", "sources",
+            "cons_home", "cons_draw", "cons_away",
+            "cons_over_25", "cons_under_25",
+            "cons_btts_yes", "cons_btts_no",
+            "odds_home", "odds_draw", "odds_away",
+            "odds_over_25", "odds_under_25",
+            "odds_btts_yes", "odds_btts_no",
+            "result_url", "league"
+        ]
+        for field in required_fields:
+            assert field in match, f"Missing field: {field}"
+        
+        assert match["sources"] >= 3
+        assert match["odds_home"] > 1.0
+        assert match["odds_draw"] > 1.0
+        assert match["odds_away"] > 1.0
+
+
+class TestProfilesEndpoint:
+    """Test /api/profiles endpoint with data_source parameter."""
+
+    def test_profiles_demo_data_source(self, client):
+        """Test profiles endpoint with data_source=demo."""
+        response = client.get("/api/profiles", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "profiles" in data
+        profiles = data["profiles"]
+        
+        assert set(profiles.keys()) == {"Conservative", "Balanced", "Aggressive"}
+        
+        for profile_name, config in profiles.items():
+            required_fields = [
+                "target_odds", "target_legs", "max_legs_overflow",
+                "consensus_floor", "min_odds", "tolerance_factor",
+                "stop_threshold", "min_legs_fill_ratio",
+                "quality_vs_balance", "consensus_vs_sources",
+                "included_markets", "included_leagues",
+                "units", "target_payout", "run_daily_count"
+            ]
+            for field in required_fields:
+                assert field in config, f"Missing field {field} in {profile_name}"
+            
+            if profile_name == "Conservative":
+                assert config["target_odds"] == 2.0
+                assert config["target_legs"] == 1
+                assert config["units"] == 1.0
+            elif profile_name == "Balanced":
+                assert config["target_odds"] == 3.5
+                assert config["target_legs"] == 2
+                assert config["units"] == 1.5
+            elif profile_name == "Aggressive":
+                assert config["target_odds"] == 6.0
+                assert config["target_legs"] == 3
+                assert config["units"] == 2.0
+
+    def test_profiles_live_data_source(self, client):
+        """Test profiles endpoint with data_source=live."""
+        response = client.get("/api/profiles", params={"data_source": "live"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "profiles" in data
+
+    def test_profiles_invalid_data_source(self, client):
+        """Test profiles endpoint with invalid data_source."""
+        response = client.get("/api/profiles", params={"data_source": "invalid"})
+        assert response.status_code == 422
+
+
+class TestOddsHistoryEndpoint:
+    """Test /api/odds-history endpoint with data_source parameter."""
+
+    def test_odds_history_demo_data_source(self, client):
+        """Test odds history endpoint with data_source=demo."""
+        # First get a match ID that has odds history
+        response = client.get("/api/matches", params={"data_source": "demo", "page_size": 1})
+        assert response.status_code == 200
+        matches = response.json()["matches"]
+        assert len(matches) > 0
+        match_id = matches[0]["match_id"]
+        
+        response = client.get(f"/api/odds-history/{match_id}", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert "match_id" in data
+        assert "match_name" in data
+        assert "datetime" in data
+        assert "snapshots" in data
+        assert "movement" in data
+        
+        assert data["match_id"] == match_id
+        assert len(data["snapshots"]) == 30  # 30 days of history
+        
+        # Verify snapshots structure
+        for snapshot in data["snapshots"]:
+            assert "timestamp" in snapshot
+            assert "odds" in snapshot
+            odds = snapshot["odds"]
+            assert "home" in odds
+            assert "draw" in odds
+            assert "away" in odds
+            assert "over_25" in odds
+            assert "under_25" in odds
+            assert "btts_yes" in odds
+            assert "btts_no" in odds
+            for v in odds.values():
+                assert v >= 1.01
+        
+        # Verify movement structure
+        movement = data["movement"]
+        for key, value in movement.items():
+            assert value in ("up", "down", "stable")
+
+    def test_odds_history_live_data_source(self, client):
+        """Test odds history endpoint with data_source=live."""
+        response = client.get("/api/odds-history/0", params={"data_source": "live"})
+        # May return 404 if no live data, but should not error
+        assert response.status_code in (200, 404)
+
+    def test_odds_history_invalid_data_source(self, client):
+        """Test odds history endpoint with invalid data_source."""
+        response = client.get("/api/odds-history/0", params={"data_source": "invalid"})
+        assert response.status_code == 422
+
+    def test_odds_history_invalid_match(self, client):
+        """Test odds history for invalid match ID."""
+        response = client.get("/api/odds-history/999999", params={"data_source": "demo"})
+        assert response.status_code == 404
+
+    def test_all_movements_demo(self, client):
+        """Test get_all_movements with demo data."""
+        response = client.get("/api/odds-history/movements/all", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert isinstance(data, dict)
+        for match_id, movement in data.items():
+            assert isinstance(match_id, str)
+            assert isinstance(movement, dict)
+            for key, value in movement.items():
+                assert value in ("up", "down", "stable")
+
+    def test_significant_movements_demo(self, client):
+        """Test get_significant_movements with demo data."""
+        response = client.get("/api/odds-history/movements/significant", params={"data_source": "demo"})
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert isinstance(data, dict)
+        for match_id, movement in data.items():
+            assert isinstance(match_id, str)
+            assert isinstance(movement, dict)
+            # Should have at least one significant movement
+            sig_count = sum(1 for v in movement.values() if v in ("up", "down"))
+            assert sig_count > 0
+
+
+class TestDataSourceRouting:
+    """Test that data_source parameter correctly routes to demo or live provider."""
+
+    def test_all_endpoints_accept_data_source(self, client):
+        """Verify all 5 endpoints accept data_source parameter."""
+        endpoints = [
+            "/api/analytics",
+            "/api/slips",
+            "/api/matches",
+            "/api/profiles",
+            "/api/odds-history/movements/all",
+        ]
+        
+        for endpoint in endpoints:
+            # Test with demo
+            response = client.get(endpoint, params={"data_source": "demo"})
+            assert response.status_code == 200, f"Failed for {endpoint} with demo"
+            
+            # Test with live
+            response = client.get(endpoint, params={"data_source": "live"})
+            assert response.status_code == 200, f"Failed for {endpoint} with live"
+            
+            # Test default (should be live)
+            response = client.get(endpoint)
+            assert response.status_code == 200, f"Failed for {endpoint} with default"
+
+    def test_demo_data_is_deterministic(self, client):
+        """Verify demo data is deterministic across requests."""
+        # Make two requests for the same endpoint with demo data
+        response1 = client.get("/api/analytics", params={"data_source": "demo"})
+        response2 = client.get("/api/analytics", params={"data_source": "demo"})
+        
+        assert response1.status_code == 200
+        assert response2.status_code == 200
+        assert response1.json() == response2.json()
+        
+        # Test slips endpoint
+        response1 = client.get("/api/slips", params={"data_source": "demo"})
+        response2 = client.get("/api/slips", params={"data_source": "demo"})
+        
+        assert response1.status_code == 200
+        assert response2.status_code == 200
+        assert response1.json() == response2.json()
+        
+        # Test matches endpoint
+        response1 = client.get("/api/matches", params={"data_source": "demo"})
+        response2 = client.get("/api/matches", params={"data_source": "demo"})
+        
+        assert response1.status_code == 200
+        assert response2.status_code == 200
+        assert response1.json() == response2.json()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_demo_data_provider.py
+++ b/tests/test_demo_data_provider.py
@@ -1,0 +1,780 @@
+"""
+Comprehensive unit tests for DemoDataProvider.
+
+Tests the deterministic demo data generation, all public API methods,
+and verifies calculations match expected values for the seeded scenario.
+"""
+
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timedelta
+from typing import Any
+
+from bet_dashboard.backend.fixtures.demo_data import (
+    DemoDataProvider,
+    BetSlip,
+    BetLeg,
+    Match,
+    Outcome,
+    SlipStatus,
+    get_demo_provider,
+)
+
+
+class TestDemoDataProviderInitialization:
+    """Test DemoDataProvider initialization and deterministic generation."""
+
+    def test_singleton_instance(self):
+        """Verify get_demo_provider returns the same instance."""
+        provider1 = get_demo_provider()
+        provider2 = get_demo_provider()
+        assert provider1 is provider2
+
+    def test_deterministic_generation_same_seed(self):
+        """Verify same seed produces identical data."""
+        provider1 = DemoDataProvider(seed=42)
+        provider2 = DemoDataProvider(seed=42)
+        
+        # Check slips are identical
+        assert len(provider1._slips) == len(provider2._slips)
+        for s1, s2 in zip(provider1._slips, provider2._slips):
+            assert s1.slip_id == s2.slip_id
+            assert s1.profile == s2.profile
+            assert s1.total_odds == s2.total_odds
+            assert s1.units == s2.units
+            assert s1.slip_status == s2.slip_status
+            assert s1.net_profit == s2.net_profit
+            assert len(s1.legs) == len(s2.legs)
+            for l1, l2 in zip(s1.legs, s2.legs):
+                assert l1.match_name == l2.match_name
+                assert l1.market == l2.market
+                assert l1.odds == l2.odds
+                assert l1.status == l2.status
+
+    def test_different_seeds_produce_different_data(self):
+        """Verify different seeds produce different data."""
+        provider1 = DemoDataProvider(seed=42)
+        provider2 = DemoDataProvider(seed=123)
+        
+        # At least one slip should differ
+        assert provider1._slips != provider2._slips
+
+    def test_data_generation_counts(self):
+        """Verify expected data generation counts."""
+        provider = DemoDataProvider(seed=42)
+        
+        # Should have ~632 matches over 6 months (actual count with seed=42)
+        assert len(provider._matches) == 632
+        
+        # Should have ~350 slips
+        assert len(provider._slips) == 350
+        
+        # Should have 3 profiles
+        profiles = {s.profile for s in provider._slips}
+        assert profiles == {"Conservative", "Balanced", "Aggressive"}
+        
+        # Should have odds history for matches in slips
+        assert len(provider._odds_history) > 0
+
+    def test_status_distribution(self):
+        """Verify status distribution matches actual ratios for seed=42."""
+        provider = DemoDataProvider(seed=42)
+        
+        statuses = [s.slip_status for s in provider._slips]
+        total = len(statuses)
+        
+        won_pct = statuses.count(SlipStatus.WON.value) / total * 100
+        lost_pct = statuses.count(SlipStatus.LOST.value) / total * 100
+        pending_pct = statuses.count(SlipStatus.PENDING.value) / total * 100
+        live_pct = statuses.count(SlipStatus.LIVE.value) / total * 100
+        
+        # Actual distribution for seed=42: ~19% won, ~67% lost, ~13% pending, ~1% live
+        assert 15 <= won_pct <= 25
+        assert 60 <= lost_pct <= 75
+        assert 10 <= pending_pct <= 20
+        assert 0 <= live_pct <= 5
+
+
+class TestDemoDataProviderGetAnalytics:
+    """Test get_analytics method with various filters."""
+
+    @pytest.fixture
+    def provider(self):
+        return DemoDataProvider(seed=42)
+
+    def test_get_analytics_all_data(self, provider):
+        """Test analytics with no filters returns all data."""
+        result = provider.get_analytics(None, None, None)
+        
+        # Verify all expected keys present
+        expected_keys = [
+            "history", "market_accuracy", "pnl_by_market", "odds_distribution",
+            "correlation", "profile_scatter", "stats", "profiles",
+            "market_breakdown", "league_breakdown", "rolling_edge",
+            "drawdown", "return_distribution", "time_patterns",
+            "correlation_matrix", "profit_attribution"
+        ]
+        for key in expected_keys:
+            assert key in result, f"Missing key: {key}"
+        
+        # Verify stats structure
+        stats = result["stats"]
+        assert stats["total_settled"] > 0
+        assert stats["total_won_count"] >= 0
+        assert 0 <= stats["win_rate"] <= 100
+        assert stats["total_units_bet"] > 0
+        assert stats["net_profit"] != 0  # Should have some profit/loss
+        assert stats["roi_percentage"] != 0
+        assert stats["avg_odds"] > 1.0
+        assert stats["profit_factor"] >= 0
+
+    def test_get_analytics_profile_filter(self, provider):
+        """Test analytics filtered by profile."""
+        result = provider.get_analytics(["Conservative"], None, None)
+        
+        stats = result["stats"]
+        assert stats["total_settled"] > 0
+        
+        # All slips should be Conservative
+        profiles_in_result = {s["profile"] for s in result["profile_scatter"]}
+        assert profiles_in_result == {"Conservative"}
+
+    def test_get_analytics_date_filter(self, provider):
+        """Test analytics filtered by date range."""
+        result = provider.get_analytics(None, "2026-03-01", "2026-03-31")
+        
+        stats = result["stats"]
+        # Should have fewer slips than full dataset
+        full_result = provider.get_analytics(None, None, None)
+        assert stats["total_settled"] <= full_result["stats"]["total_settled"]
+        
+        # All history dates should be in March 2026
+        for day in result["history"]:
+            assert day["date"].startswith("2026-03")
+
+    def test_get_analytics_empty_result(self, provider):
+        """Test analytics with date range that has no data."""
+        result = provider.get_analytics(None, "2020-01-01", "2020-01-31")
+        
+        stats = result["stats"]
+        assert stats["total_settled"] == 0
+        assert stats["win_rate"] == 0.0
+        assert stats["net_profit"] == 0.0
+        assert result["history"] == []
+        assert result["market_accuracy"] == []
+        assert result["pnl_by_market"] == []
+
+    def test_history_cumulative_calculations(self, provider):
+        """Verify daily history cumulative calculations are correct."""
+        result = provider.get_analytics(None, None, None)
+        history = result["history"]
+        
+        cumulative_profit = 0.0
+        cumulative_bet = 0.0
+        
+        for day in history:
+            cumulative_profit += day["net_profit"]
+            cumulative_bet += day["units_bet"]
+            
+            assert abs(day["cumulative_profit"] - cumulative_profit) < 0.01
+            assert abs(day["cumulative_bet"] - cumulative_bet) < 0.01
+            
+            if cumulative_bet > 0:
+                expected_roi = round(cumulative_profit / cumulative_bet * 100, 2)
+                assert abs(day["roi_percentage"] - expected_roi) < 0.01
+
+    def test_market_accuracy_calculations(self, provider):
+        """Verify market accuracy calculations."""
+        result = provider.get_analytics(None, None, None)
+        market_accuracy = result["market_accuracy"]
+        
+        for market in market_accuracy:
+            total = market["total"]
+            won = market["won"]
+            lost = market["lost"]
+            accuracy = market["accuracy"]
+            
+            assert total == won + lost
+            if total > 0:
+                expected_accuracy = round(won / total * 100, 1)
+                assert abs(accuracy - expected_accuracy) < 0.1
+            else:
+                assert accuracy == 0.0
+
+    def test_pnl_by_market_calculations(self, provider):
+        """Verify PnL by market calculations."""
+        result = provider.get_analytics(None, None, None)
+        pnl_by_market = result["pnl_by_market"]
+        
+        for market in pnl_by_market:
+            won = market["won"]
+            lost = market["lost"]
+            net_profit = market["net_profit"]
+            
+            # Net profit should be consistent with won/lost counts
+            # (exact verification requires knowing per-leg stakes)
+            assert isinstance(net_profit, (int, float))
+
+    def test_odds_distribution_buckets(self, provider):
+        """Verify odds distribution bucket calculations."""
+        result = provider.get_analytics(None, None, None)
+        odds_dist = result["odds_distribution"]
+        
+        for bucket in odds_dist:
+            count = bucket["count"]
+            wins = bucket["wins"]
+            losses = bucket["losses"]
+            win_rate = bucket["win_rate"]
+            implied_win_rate = bucket["implied_win_rate"]
+            edge = bucket["edge"]
+            
+            assert count == wins + losses
+            if count > 0:
+                assert abs(win_rate - round(wins / count * 100, 1)) < 0.1
+                assert abs(edge - round(win_rate - implied_win_rate, 1)) < 0.1
+            assert bucket["avg_odds"] > 1.0
+
+    def test_profile_scatter_calculations(self, provider):
+        """Verify profile scatter calculations."""
+        result = provider.get_analytics(None, None, None)
+        profile_scatter = result["profile_scatter"]
+        
+        for profile_data in profile_scatter:
+            profile = profile_data["profile"]
+            avg_odds = profile_data["avg_odds"]
+            win_rate = profile_data["win_rate"]
+            net_profit = profile_data["net_profit"]
+            volume = profile_data["volume"]
+            break_even = profile_data["break_even_win_rate"]
+            
+            assert profile in ["Conservative", "Balanced", "Aggressive"]
+            assert avg_odds > 1.0
+            assert 0 <= win_rate <= 100
+            assert volume > 0
+            if avg_odds > 0:
+                expected_be = round(100 / avg_odds, 1)
+                assert abs(break_even - expected_be) < 0.1
+
+    def test_stats_calculations(self, provider):
+        """Verify stats calculations are internally consistent."""
+        result = provider.get_analytics(None, None, None)
+        stats = result["stats"]
+        
+        total_settled = stats["total_settled"]
+        total_won = stats["total_won_count"]
+        win_rate = stats["win_rate"]
+        total_units = stats["total_units_bet"]
+        net_profit = stats["net_profit"]
+        roi = stats["roi_percentage"]
+        avg_odds = stats["avg_odds"]
+        implied_wr = stats["implied_win_rate"]
+        edge = stats["edge"]
+        profit_factor = stats["profit_factor"]
+        
+        if total_settled > 0:
+            assert abs(win_rate - round(total_won / total_settled * 100, 1)) < 0.1
+            if total_units > 0:
+                assert abs(roi - round(net_profit / total_units * 100, 2)) < 0.01
+            assert abs(edge - round(win_rate - implied_wr, 1)) < 0.1
+            assert profit_factor >= 0
+
+    def test_market_breakdown_sorted_by_edge(self, provider):
+        """Verify market breakdown is sorted by edge descending."""
+        result = provider.get_analytics(None, None, None)
+        market_breakdown = result["market_breakdown"]
+        
+        edges = [m["edge"] for m in market_breakdown]
+        assert edges == sorted(edges, reverse=True)
+        
+        for market in market_breakdown:
+            total = market["legs"]
+            won = market["won"]
+            lost = market["lost"]
+            win_rate = market["win_rate"]
+            implied = market["implied_win_rate"]
+            edge = market["edge"]
+            
+            assert total == won + lost
+            if total > 0:
+                assert abs(win_rate - round(won / total * 100, 1)) < 0.1
+                assert abs(edge - round(win_rate - implied, 1)) < 0.1
+
+    def test_league_breakdown_sorted_by_edge(self, provider):
+        """Verify league breakdown is sorted by edge descending."""
+        result = provider.get_analytics(None, None, None)
+        league_breakdown = result["league_breakdown"]
+        
+        edges = [l["edge"] for l in league_breakdown]
+        assert edges == sorted(edges, reverse=True)
+
+    def test_rolling_edge_calculations(self, provider):
+        """Verify rolling edge calculations."""
+        result = provider.get_analytics(None, None, None)
+        rolling_edge = result["rolling_edge"]
+        
+        for day in rolling_edge:
+            rolling_wr = day["rolling_win_rate"]
+            rolling_implied = day["rolling_implied"]
+            rolling_edge_val = day["rolling_edge"]
+            
+            assert abs(rolling_edge_val - round(rolling_wr - rolling_implied, 1)) < 0.1
+            assert day["sample_size"] > 0
+
+    def test_drawdown_calculations(self, provider):
+        """Verify drawdown calculations."""
+        result = provider.get_analytics(None, None, None)
+        drawdown = result["drawdown"]
+        
+        peak = 0.0
+        for day in drawdown:
+            cum = day["cumulative_profit"]
+            if cum > peak:
+                peak = cum
+            expected_dd = round(cum - peak, 2)
+            assert abs(day["drawdown"] - expected_dd) < 0.01
+            assert abs(day["peak"] - peak) < 0.01
+            assert day["drawdown"] <= 0  # Drawdown should be <= 0
+
+    def test_return_distribution(self, provider):
+        """Verify return distribution calculations."""
+        result = provider.get_analytics(None, None, None)
+        ret_dist = result["return_distribution"]
+        
+        if ret_dist:
+            assert "bins" in ret_dist
+            assert "mean" in ret_dist
+            assert "median" in ret_dist
+            assert len(ret_dist["bins"]) == 10
+            
+            total_count = sum(b["count"] for b in ret_dist["bins"])
+            assert total_count > 0
+
+    def test_time_patterns(self, provider):
+        """Verify time patterns calculations."""
+        result = provider.get_analytics(None, None, None)
+        time_patterns = result["time_patterns"]
+        
+        if time_patterns:
+            assert "day_of_week" in time_patterns
+            dow = time_patterns["day_of_week"]
+            for day in dow:
+                assert "key" in day
+                assert "total" in day
+                assert "won" in day
+                assert "win_rate" in day
+                if day["total"] > 0:
+                    assert abs(day["win_rate"] - round(day["won"] / day["total"] * 100, 1)) < 0.1
+
+    def test_correlation_matrix(self, provider):
+        """Verify correlation matrix structure."""
+        result = provider.get_analytics(None, None, None)
+        corr_matrix = result["correlation_matrix"]
+        
+        assert "leagues" in corr_matrix
+        assert "markets" in corr_matrix
+        assert "matrix" in corr_matrix
+        
+        for league in corr_matrix["leagues"]:
+            assert league in corr_matrix["matrix"]
+            for market in corr_matrix["markets"]:
+                if market in corr_matrix["matrix"][league]:
+                    cell = corr_matrix["matrix"][league][market]
+                    assert "win_rate" in cell
+                    assert "edge" in cell
+                    assert "total" in cell
+                    assert cell["total"] > 0
+
+    def test_profit_attribution(self, provider):
+        """Verify profit attribution calculations."""
+        result = provider.get_analytics(None, None, None)
+        profit_attr = result["profit_attribution"]
+        
+        assert "total_profit" in profit_attr
+        assert "components" in profit_attr
+        
+        total_profit = profit_attr["total_profit"]
+        components = profit_attr["components"]
+        
+        # Sum of component values should approximately equal total_profit
+        component_sum = sum(c["value"] for c in components)
+        assert abs(component_sum - total_profit) < 1.0  # Allow small rounding differences
+        
+        # Percentages should sum to approximately 100%
+        pct_sum = sum(c["percentage"] for c in components)
+        assert abs(pct_sum - 100) < 5  # Allow some tolerance
+
+
+class TestDemoDataProviderGetSlips:
+    """Test get_slips method with various filters."""
+
+    @pytest.fixture
+    def provider(self):
+        return DemoDataProvider(seed=42)
+
+    def test_get_slips_all(self, provider):
+        """Test getting all slips."""
+        result = provider.get_slips(None, None, None, False, False)
+        
+        assert "slips" in result
+        assert "stats" in result
+        assert "profiles" in result
+        assert len(result["slips"]) == len(provider._slips)
+        assert set(result["profiles"]) == {"Conservative", "Balanced", "Aggressive"}
+
+    def test_get_slips_profile_filter(self, provider):
+        """Test slips filtered by profile."""
+        result = provider.get_slips(["Conservative"], None, None, False, False)
+        
+        for slip in result["slips"]:
+            assert slip["profile"] == "Conservative"
+        # Note: profiles field returns all profiles that have slips in the date range
+        # not just the filtered profile
+        assert "Conservative" in result["profiles"]
+
+    def test_get_slips_date_filter(self, provider):
+        """Test slips filtered by date range."""
+        result = provider.get_slips(None, "2026-03-01", "2026-03-31", False, False)
+        
+        for slip in result["slips"]:
+            assert "2026-03" <= slip["date_generated"] <= "2026-03-31"
+
+    def test_get_slips_hide_settled(self, provider):
+        """Test hide_settled filter."""
+        result = provider.get_slips(None, None, None, True, False)
+        
+        for slip in result["slips"]:
+            assert slip["slip_status"] not in (SlipStatus.WON.value, SlipStatus.LOST.value)
+            assert slip["slip_status"] in (SlipStatus.PENDING.value, SlipStatus.LIVE.value)
+
+    def test_get_slips_live_only(self, provider):
+        """Test live_only filter."""
+        result = provider.get_slips(None, None, None, False, True)
+        
+        for slip in result["slips"]:
+            assert any(leg["status"] == Outcome.LIVE.value for leg in slip["legs"])
+
+    def test_slip_structure(self, provider):
+        """Verify slip data structure."""
+        result = provider.get_slips(None, None, None, False, False)
+        slip = result["slips"][0]
+        
+        assert "slip_id" in slip
+        assert "date_generated" in slip
+        assert "profile" in slip
+        assert "total_odds" in slip
+        assert "units" in slip
+        assert "slip_status" in slip
+        assert "legs" in slip
+        assert "net_profit" in slip
+        
+        assert isinstance(slip["legs"], list)
+        assert len(slip["legs"]) > 0
+        
+        leg = slip["legs"][0]
+        assert "match_name" in leg
+        assert "datetime" in leg
+        assert "market" in leg
+        assert "market_type" in leg
+        assert "odds" in leg
+        assert "status" in leg
+        assert "result_url" in leg
+        assert "league" in leg
+
+    def test_net_profit_calculation(self, provider):
+        """Verify net_profit calculation for settled slips."""
+        result = provider.get_slips(None, None, None, False, False)
+        
+        for slip in result["slips"]:
+            if slip["slip_status"] == SlipStatus.WON.value:
+                expected_profit = round((slip["total_odds"] - 1) * slip["units"], 2)
+                assert abs(slip["net_profit"] - expected_profit) < 0.01
+            elif slip["slip_status"] == SlipStatus.LOST.value:
+                expected_profit = round(-slip["units"], 2)
+                assert abs(slip["net_profit"] - expected_profit) < 0.01
+            else:
+                assert slip["net_profit"] is None
+
+
+class TestDemoDataProviderGetMatches:
+    """Test get_matches method with various filters."""
+
+    @pytest.fixture
+    def provider(self):
+        return DemoDataProvider(seed=42)
+
+    def test_get_matches_default(self, provider):
+        """Test default matches pagination."""
+        result = provider.get_matches()
+        
+        assert "total" in result
+        assert "page" in result
+        assert "page_size" in result
+        assert "total_pages" in result
+        assert "matches" in result
+        assert result["page"] == 1
+        assert result["page_size"] == 40
+        assert len(result["matches"]) <= 40
+        assert result["total"] == len(provider._matches)
+
+    def test_get_matches_pagination(self, provider):
+        """Test matches pagination."""
+        page1 = provider.get_matches(page=1, page_size=10)
+        page2 = provider.get_matches(page=2, page_size=10)
+        
+        assert page1["page"] == 1
+        assert page2["page"] == 2
+        assert len(page1["matches"]) == 10
+        assert len(page2["matches"]) == 10
+        assert page1["matches"][0]["match_id"] != page2["matches"][0]["match_id"]
+        assert page1["total"] == page2["total"]
+        assert page1["total_pages"] == page2["total_pages"]
+
+    def test_get_matches_search(self, provider):
+        """Test matches search filter."""
+        # Search for a known team
+        result = provider.get_matches(search="Arsenal")
+        
+        for match in result["matches"]:
+            assert "arsenal" in match["home"].lower() or "arsenal" in match["away"].lower()
+
+    def test_get_matches_date_filter(self, provider):
+        """Test matches date range filter."""
+        result = provider.get_matches(date_from="2026-03-01", date_to="2026-03-31")
+        
+        for match in result["matches"]:
+            if match["datetime"]:
+                assert "2026-03" <= match["datetime"][:10] <= "2026-03-31"
+
+    def test_get_matches_sort(self, provider):
+        """Test matches sorting."""
+        result = provider.get_matches(sort_by="datetime", sort_dir="asc")
+        
+        dates = [m["datetime"] for m in result["matches"] if m["datetime"]]
+        assert dates == sorted(dates)
+        
+        result_desc = provider.get_matches(sort_by="datetime", sort_dir="desc")
+        dates_desc = [m["datetime"] for m in result_desc["matches"] if m["datetime"]]
+        assert dates_desc == sorted(dates_desc, reverse=True)
+
+    def test_get_matches_min_consensus(self, provider):
+        """Test min_consensus filter."""
+        result = provider.get_matches(min_consensus=60)
+        
+        for match in result["matches"]:
+            # At least one market should have consensus >= 60
+            consensus_values = [
+                match.get("cons_over_05", 0),
+                match.get("cons_under_05", 0),
+                match.get("cons_over_15", 0),
+                match.get("cons_under_15", 0),
+                match.get("cons_over_35", 0),
+                match.get("cons_under_35", 0),
+                match.get("cons_over_45", 0),
+                match.get("cons_under_45", 0),
+                match.get("cons_dc_1x", 0),
+                match.get("cons_dc_12", 0),
+                match.get("cons_dc_x2", 0),
+                match.get("cons_home", 0),
+                match.get("cons_draw", 0),
+                match.get("cons_away", 0),
+                match.get("cons_over_25", 0),
+                match.get("cons_under_25", 0),
+                match.get("cons_btts_yes", 0),
+                match.get("cons_btts_no", 0),
+            ]
+            assert max(consensus_values) >= 60
+
+    def test_get_matches_min_odds(self, provider):
+        """Test min_odds filter."""
+        result = provider.get_matches(min_odds=3.0)
+        
+        for match in result["matches"]:
+            odds_values = [
+                match.get("odds_home", 0),
+                match.get("odds_draw", 0),
+                match.get("odds_away", 0),
+                match.get("odds_over_25", 0),
+                match.get("odds_under_25", 0),
+                match.get("odds_btts_yes", 0),
+                match.get("odds_btts_no", 0),
+            ]
+            assert max(odds_values) >= 3.0
+
+    def test_match_structure(self, provider):
+        """Verify match data structure."""
+        result = provider.get_matches(page_size=1)
+        match = result["matches"][0]
+        
+        required_fields = [
+            "match_id", "datetime", "home", "away", "sources",
+            "cons_home", "cons_draw", "cons_away",
+            "cons_over_25", "cons_under_25",
+            "cons_btts_yes", "cons_btts_no",
+            "odds_home", "odds_draw", "odds_away",
+            "odds_over_25", "odds_under_25",
+            "odds_btts_yes", "odds_btts_no",
+            "result_url", "league"
+        ]
+        for field in required_fields:
+            assert field in match, f"Missing field: {field}"
+        
+        assert match["sources"] >= 3
+        assert match["odds_home"] > 1.0
+        assert match["odds_draw"] > 1.0
+        assert match["odds_away"] > 1.0
+
+
+class TestDemoDataProviderGetProfiles:
+    """Test get_profiles method."""
+
+    @pytest.fixture
+    def provider(self):
+        return DemoDataProvider(seed=42)
+
+    def test_get_profiles_structure(self, provider):
+        """Verify profiles structure."""
+        result = provider.get_profiles()
+        
+        assert "profiles" in result
+        profiles = result["profiles"]
+        
+        assert set(profiles.keys()) == {"Conservative", "Balanced", "Aggressive"}
+        
+        for profile_name, config in profiles.items():
+            required_fields = [
+                "target_odds", "target_legs", "max_legs_overflow",
+                "consensus_floor", "min_odds", "tolerance_factor",
+                "stop_threshold", "min_legs_fill_ratio",
+                "quality_vs_balance", "consensus_vs_sources",
+                "included_markets", "included_leagues",
+                "units", "target_payout", "run_daily_count"
+            ]
+            for field in required_fields:
+                assert field in config, f"Missing field {field} in {profile_name}"
+            
+            # Verify profile-specific values
+            if profile_name == "Conservative":
+                assert config["target_odds"] == 2.0
+                assert config["target_legs"] == 1
+                assert config["units"] == 1.0
+            elif profile_name == "Balanced":
+                assert config["target_odds"] == 3.5
+                assert config["target_legs"] == 2
+                assert config["units"] == 1.5
+            elif profile_name == "Aggressive":
+                assert config["target_odds"] == 6.0
+                assert config["target_legs"] == 3
+                assert config["units"] == 2.0
+
+
+class TestDemoDataProviderGetOddsHistory:
+    """Test get_odds_history method."""
+
+    @pytest.fixture
+    def provider(self):
+        return DemoDataProvider(seed=42)
+
+    def test_get_odds_history_valid_match(self, provider):
+        """Test odds history for a valid match."""
+        # Find a match with odds history
+        match_ids_with_history = list(provider._odds_history.keys())
+        assert len(match_ids_with_history) > 0
+        
+        match_id = match_ids_with_history[0]
+        result = provider.get_odds_history(match_id)
+        
+        assert "match_id" in result
+        assert "match_name" in result
+        assert "datetime" in result
+        assert "snapshots" in result
+        assert "movement" in result
+        
+        assert result["match_id"] == match_id
+        assert len(result["snapshots"]) == 30  # 30 days of history
+        
+        # Verify snapshots structure
+        for snapshot in result["snapshots"]:
+            assert "timestamp" in snapshot
+            assert "odds" in snapshot
+            odds = snapshot["odds"]
+            assert "home" in odds
+            assert "draw" in odds
+            assert "away" in odds
+            assert "over_25" in odds
+            assert "under_25" in odds
+            assert "btts_yes" in odds
+            assert "btts_no" in odds
+            for v in odds.values():
+                assert v >= 1.01
+        
+        # Verify movement structure
+        movement = result["movement"]
+        for key, value in movement.items():
+            assert value in ("up", "down", "stable")
+
+    def test_get_odds_history_invalid_match(self, provider):
+        """Test odds history for invalid match ID."""
+        with pytest.raises(ValueError, match="Match 999999 not found"):
+            provider.get_odds_history(999999)
+
+    def test_get_all_movements(self, provider):
+        """Test get_all_movements."""
+        result = provider.get_all_movements()
+        
+        assert isinstance(result, dict)
+        for match_id, movement in result.items():
+            assert isinstance(match_id, str)
+            assert isinstance(movement, dict)
+            for key, value in movement.items():
+                assert value in ("up", "down", "stable")
+
+    def test_get_significant_movements(self, provider):
+        """Test get_significant_movements."""
+        result = provider.get_significant_movements()
+        
+        assert isinstance(result, dict)
+        for match_id, movement in result.items():
+            assert isinstance(match_id, str)
+            assert isinstance(movement, dict)
+            # Should have at least one significant movement
+            sig_count = sum(1 for v in movement.values() if v in ("up", "down"))
+            assert sig_count > 0
+
+
+class TestDemoDataProviderDeterministic:
+    """Test that demo data is fully deterministic."""
+
+    def test_full_determinism(self):
+        """Verify complete determinism across all methods."""
+        provider1 = DemoDataProvider(seed=42)
+        provider2 = DemoDataProvider(seed=42)
+        
+        # Test all public methods return identical results
+        assert provider1.get_analytics(None, None, None) == provider2.get_analytics(None, None, None)
+        assert provider1.get_slips(None, None, None, False, False) == provider2.get_slips(None, None, None, False, False)
+        assert provider1.get_matches() == provider2.get_matches()
+        assert provider1.get_profiles() == provider2.get_profiles()
+        
+        # Test odds history for all matches with history
+        for match_id in provider1._odds_history:
+            assert provider1.get_odds_history(match_id) == provider2.get_odds_history(match_id)
+        
+        assert provider1.get_all_movements() == provider2.get_all_movements()
+        assert provider1.get_significant_movements() == provider2.get_significant_movements()
+
+    def test_filtered_determinism(self):
+        """Verify determinism with filters."""
+        provider1 = DemoDataProvider(seed=42)
+        provider2 = DemoDataProvider(seed=42)
+        
+        assert provider1.get_analytics(["Conservative"], "2026-03-01", "2026-03-31") == \
+               provider2.get_analytics(["Conservative"], "2026-03-01", "2026-03-31")
+        assert provider1.get_slips(["Balanced"], "2026-04-01", "2026-04-30", True, False) == \
+               provider2.get_slips(["Balanced"], "2026-04-01", "2026-04-30", True, False)
+        assert provider1.get_matches(page=2, page_size=20, search="Real", sort_by="home") == \
+               provider2.get_matches(page=2, page_size=20, search="Real", sort_by="home")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add DemoDataProvider with deterministic seeded fixtures (6 months, 3 profiles, ~300-450 slips)
- Add data_source=demo|live query param to all dashboard API endpoints
- Add toggle switch in Layout.tsx header near refresh/pull buttons
- Add DataSourceContext + useDataSource hook with localStorage persistence
- Update data.ts to pass data_source to all fetch calls
- Add DataSource type to types/index.ts

Enables dashboard demos with realistic pre-built data without affecting live data flow.